### PR TITLE
Support PT 2.8 bincount

### DIFF
--- a/habana_eager/kernels_impl.cpp
+++ b/habana_eager/kernels_impl.cpp
@@ -31,6 +31,7 @@
 #include "habana_eager/ops/unique2.h"
 #include "habana_eager/ops/view.h"
 #include "habana_helpers/logging.h"
+#include "habana_helpers/pt_version_check.h"
 #include "habana_kernels/wrap_kernels_declarations.h"
 #include "hpu_ops/cpu_fallback.h"
 #include "hpu_ops/op_logger.h"
@@ -222,7 +223,11 @@ at::Tensor& hpu_wrap::_index_put_impl_(
 at::Tensor hpu_wrap::bincount(
     const at::Tensor& self,
     const std::optional<at::Tensor>& weights,
+#if IS_PYTORCH_AT_LEAST(2, 8)
+    c10::SymInt minlength) {
+#else
     int64_t minlength) {
+#endif
   PT_EAGER_TRACE;
   PT_OP_INFO("bincount :", DUMP_3ARGS(self, weights, minlength));
   static const std::array<c10::ScalarType, 5> valid_self_types = {

--- a/habana_eager/ops/bincount.cpp
+++ b/habana_eager/ops/bincount.cpp
@@ -16,6 +16,7 @@
 #include "hpu_ops/bincount.h"
 #include "habana_eager/ops/bincount.h"
 #include "habana_eager/ops/eager_op.h"
+#include "habana_helpers/pt_version_check.h"
 
 namespace habana {
 namespace eager {
@@ -58,7 +59,11 @@ c10::ScalarType bincount_output_dtype(
 at::Tensor bincount_eager(
     const at::Tensor& self,
     const std::optional<at::Tensor>& weights,
+#if IS_PYTORCH_AT_LEAST(2, 8)
+    c10::SymInt minlength) {
+#else
     int64_t minlength) {
+#endif
   PT_EAGER_TRACE;
   HABANA_ASSERT(
       minlength >= 0 && minlength <= std::numeric_limits<int32_t>::max(),
@@ -66,7 +71,13 @@ at::Tensor bincount_eager(
   // Handle case for empty tensor where we return empty tensor with size
   if (self.numel() == 0) {
     auto output =
+#if IS_PYTORCH_AT_LEAST(2, 8)
+        at::zeros(
+            {minlength.expect_int()},
+            self.options().dtype(c10::ScalarType::Long));
+#else
         at::zeros({minlength}, self.options().dtype(c10::ScalarType::Long));
+#endif
     return output;
   }
 
@@ -79,7 +90,11 @@ at::Tensor bincount_eager(
 
   auto max_in_input =
       static_cast<int64_t>(at::max(maybe_casted_self).item<int64_t>());
+#if IS_PYTORCH_AT_LEAST(2, 8)
+  auto length = std::max(max_in_input + 1, minlength.expect_int());
+#else
   auto length = std::max(max_in_input + 1, minlength);
+#endif
   std::vector<int64_t> shape{length};
   auto out_dtype = bincount_output_dtype(weights);
 

--- a/habana_eager/ops/bincount.h
+++ b/habana_eager/ops/bincount.h
@@ -14,12 +14,18 @@
  */
 
 #pragma once
+#include <c10/core/SymInt.h>
+#include "habana_helpers/pt_version_check.h"
 
 namespace habana {
 namespace eager {
 at::Tensor bincount_eager(
     const at::Tensor& self,
     const std::optional<at::Tensor>& weights,
+#if IS_PYTORCH_AT_LEAST(2, 8)
+    c10::SymInt minlength);
+#else
     int64_t minlength);
+#endif
 } // namespace eager
 } // namespace habana

--- a/habana_kernels/kernels_register.cpp
+++ b/habana_kernels/kernels_register.cpp
@@ -19,6 +19,7 @@
 #include "common/dump_args.h"
 #include "common/random_utils.h"
 #include "generated/lazy/wrap_kernels_declarations.h"
+#include "habana_helpers/pt_version_check.h"
 #include "habana_kernels/basic_kernels.h"
 #include "habana_kernels/instance_norm_utils.h"
 #include "habana_kernels/lazy_kernels.h"
@@ -107,7 +108,11 @@ Tensor hpu_wrap::_pin_memory(
 Tensor hpu_wrap::bincount(
     const Tensor& self,
     const std::optional<Tensor>& weights,
+#if IS_PYTORCH_AT_LEAST(2, 8)
+    c10::SymInt minlength) {
+#else
     int64_t minlength) {
+#endif
   PT_LAZY_OP_TRACE;
   PT_LAZY_TRACE;
   PT_OP_INFO("bincount :", DUMP_3ARGS(self, weights, minlength));

--- a/habana_kernels/lazy_kernels.cpp
+++ b/habana_kernels/lazy_kernels.cpp
@@ -28,6 +28,7 @@
 #include "common/dump_args.h"
 #include "generated/lazy/fp8_gemm_v2.h"
 #include "habana_helpers/frontend_utils.h"
+#include "habana_helpers/pt_version_check.h"
 #include "habana_kernels/basic_kernels.h"
 #include "habana_kernels/binary_kernels.h"
 #include "habana_kernels/embedding_kernels.h"
@@ -1896,14 +1897,22 @@ c10::ScalarType bincount_output_dtype(
 Tensor bincount_hpu_lazy(
     const Tensor& self,
     const std::optional<Tensor>& weights,
+#if IS_PYTORCH_AT_LEAST(2, 8)
+    c10::SymInt minlength) {
+#else
     int64_t minlength) {
+#endif
   PT_LAZY_TRACE;
   habana_lazy::NoAccThread no_acc_thread;
 
   auto elements = self.numel();
 
   if (elements == 0) {
+#if IS_PYTORCH_AT_LEAST(2, 8)
+    auto shape = DimVector{minlength.expect_int()};
+#else
     auto shape = DimVector{minlength};
+#endif
     return at::zeros(shape, TensorOptions(kHPU).dtype(at::kLong));
   }
   const auto self_dtype = self.scalar_type();
@@ -1914,7 +1923,11 @@ Tensor bincount_hpu_lazy(
 
   auto max_in_input =
       static_cast<int64_t>(at::max(maybe_casted_self).item<int64_t>());
+#if IS_PYTORCH_AT_LEAST(2, 8)
+  int64_t length = std::max(max_in_input + 1, minlength.expect_int());
+#else
   int64_t length = std::max(max_in_input + 1, minlength);
+#endif
   std::vector<int64_t> shape{length};
   // Add bincount node
   LazyOp<at::Tensor> hpu_op{

--- a/habana_kernels/lazy_kernels_declarations.h
+++ b/habana_kernels/lazy_kernels_declarations.h
@@ -21,6 +21,7 @@
 #include <torch/script.h>
 #include <torch/version.h>
 #include "backend/habana_operator.h"
+#include "habana_helpers/pt_version_check.h"
 
 using OptionalIntArrayRef = at::OptionalIntArrayRef;
 
@@ -28,7 +29,11 @@ namespace habana_lazy {
 at::Tensor bincount_hpu_lazy(
     const at::Tensor& self,
     const std::optional<at::Tensor>& weights,
+#if IS_PYTORCH_AT_LEAST(2, 8)
+    c10::SymInt minlength);
+#else
     int64_t minlength);
+#endif
 at::Tensor _copy_from(
     const at::Tensor& self,
     const at::Tensor& dst,


### PR DESCRIPTION
PT 2.8 bincount arg type minlength
is changed from int64_t to c10::SymInt

Required after https://github.com/pytorch/pytorch/pull/152497