### PR TITLE
Fix upstream PyTorch version detection

### DIFF
--- a/python_packages/habana_frameworks/torch/__init__.py
+++ b/python_packages/habana_frameworks/torch/__init__.py
@@ -38,9 +38,9 @@ with open(REQUIRED_VERSION_FILE_PATH) as req_ver_file:
 
 run_time_ver = Version(torch.__version__)
 is_torch_fork = (
-    run_time_ver.local is not None and run_time_ver.local.startswith("git") or run_time_ver.local.startswith("hpu")
+    run_time_ver.local is not None and (run_time_ver.local.startswith("git") or run_time_ver.local.startswith("hpu"))
 )
-is_upstream_cpu = run_time_ver.local is not None and "cpu" in run_time_ver.local
+is_upstream_cpu = run_time_ver.local is None or "cpu" in run_time_ver.local
 
 if not is_torch_fork and not is_upstream_cpu:
     raise AssertionError(f"Current PyTorch version {run_time_ver} is detected as neither HPU fork nor CPU upstream.")


### PR DESCRIPTION
The upstream PyTorch version detection update had two subtle bugs. The first is the logic ordering of the first check, which needs the parenthesis so the `is not None` check fires first, then the other startswith. Otherwise it'll only `and` with the first statement and crash on local being `None` in the second one. The second bug is that if local is `None`, it'll fail to detect for the `is_upstream_cpu` check. This solves both.