### PR TITLE
Add a graph-native Triton Gaudi launch ABI

### DIFF
--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -14,6 +14,7 @@
 ###############################################################################
 
 add_subdirectory(synapse_helpers)
+find_package(OpenSSL REQUIRED COMPONENTS Crypto)
 
 add_habana_library(
   habana_pytorch_backend
@@ -27,6 +28,8 @@ add_habana_library(
   habana_operator.cpp
   scalar_cache.cpp
   random.cpp
+  triton_gaudi_custom_op.cpp
+  triton_gaudi_runtime.cpp
   cache/permute_cache.cpp
   kernel/constant_information.cpp
   kernel/control_edges_processing.cpp
@@ -97,6 +100,7 @@ target_link_libraries(
           npu::pytorch_synapse_utils_shim
           torch
           nlohmann_json::nlohmann_json
+          OpenSSL::Crypto
           absl::strings
           absl::str_format
           stdc++fs

--- a/backend/triton_gaudi_custom_op.cpp
+++ b/backend/triton_gaudi_custom_op.cpp
@@ -195,7 +195,9 @@ void validate_dynamic_quant_input(
           rows <= static_cast<std::int64_t>(
                       std::numeric_limits<std::uint32_t>::max()) &&
           rows <= std::numeric_limits<std::int64_t>::max() / n_cols &&
-          input.is_contiguous() && input.dim() == 1 && input.numel() > 0 &&
+          input.is_contiguous() && input.dim() == 2 &&
+          input.size(0) == rows && input.size(1) == n_cols &&
+          input.numel() > 0 &&
           input.numel() == n_cols * rows,
       "Triton Gaudi dynamic quantization received incompatible tensor storage");
 }
@@ -207,8 +209,8 @@ habana::PartialOutputMetaDataVector dynamic_quant_output_meta(
   const auto rows = inputs.at(4).toInt();
   validate_dynamic_quant_input(input, inputs.at(2).toInt(), n_cols, rows);
   habana::PartialOutputMetaData quantized{
-      at::kFloat8_e4m3fn, input.sizes().vec()};
-  habana::PartialOutputMetaData scale{at::kFloat, {rows}};
+      at::kFloat8_e4m3fn, {rows, n_cols}};
+  habana::PartialOutputMetaData scale{at::kFloat, {rows, 1}};
   return {quantized, scale};
 }
 
@@ -270,11 +272,12 @@ std::tuple<at::Tensor, at::Tensor> dynamic_quant_meta(
     const at::Tensor& input,
     const std::string&,
     std::int64_t,
-    std::int64_t,
+    std::int64_t n_cols,
     std::int64_t rows) {
   return {
-      at::empty_like(input, input.options().dtype(at::kFloat8_e4m3fn)),
-      at::empty({rows}, input.options().dtype(at::kFloat)),
+      at::empty(
+          {rows, n_cols}, input.options().dtype(at::kFloat8_e4m3fn)),
+      at::empty({rows, 1}, input.options().dtype(at::kFloat)),
   };
 }
 
@@ -299,9 +302,20 @@ void validate_silu_and_mul_dynamic_quant_input(
           rows <= static_cast<std::int64_t>(
                       std::numeric_limits<std::uint32_t>::max()) &&
           rows <= std::numeric_limits<std::int64_t>::max() / (2 * n_cols) &&
-          input.is_contiguous() && input.dim() == 1 &&
+          input.is_contiguous() && input.dim() == 2 &&
+          input.size(0) == rows && input.size(1) == 2 * n_cols &&
           input.numel() == 2 * n_cols * rows,
-      "Triton Gaudi fused SiLU-and-mul dynamic quantization received incompatible tensor storage");
+      "Triton Gaudi fused SiLU-and-mul dynamic quantization received "
+      "incompatible tensor storage: sizes=",
+      input.sizes(),
+      ", contiguous=",
+      input.is_contiguous(),
+      ", numel=",
+      input.numel(),
+      ", rows=",
+      rows,
+      ", n_cols=",
+      n_cols);
 }
 
 habana::PartialOutputMetaDataVector silu_and_mul_dynamic_quant_output_meta(
@@ -311,11 +325,9 @@ habana::PartialOutputMetaDataVector silu_and_mul_dynamic_quant_output_meta(
   const auto rows = inputs.at(4).toInt();
   validate_silu_and_mul_dynamic_quant_input(
       input, inputs.at(2).toInt(), n_cols, rows);
-  // The fixed-GUID perf-library ABI is flattened. Callers can restore the
-  // logical [rows, n_cols] view without a copy after graph execution.
   habana::PartialOutputMetaData quantized{
-      at::kFloat8_e4m3fn, {rows * n_cols}};
-  habana::PartialOutputMetaData scale{at::kFloat, {rows}};
+      at::kFloat8_e4m3fn, {rows, n_cols}};
+  habana::PartialOutputMetaData scale{at::kFloat, {rows, 1}};
   return {quantized, scale};
 }
 
@@ -383,8 +395,8 @@ std::tuple<at::Tensor, at::Tensor> silu_and_mul_dynamic_quant_meta(
     std::int64_t rows) {
   return {
       at::empty(
-          {rows * n_cols}, input.options().dtype(at::kFloat8_e4m3fn)),
-      at::empty({rows}, input.options().dtype(at::kFloat)),
+          {rows, n_cols}, input.options().dtype(at::kFloat8_e4m3fn)),
+      at::empty({rows, 1}, input.options().dtype(at::kFloat)),
   };
 }
 

--- a/backend/triton_gaudi_custom_op.cpp
+++ b/backend/triton_gaudi_custom_op.cpp
@@ -24,6 +24,8 @@ namespace {
 
 const std::string kFusedAddRmsNormSchema = "triton_gaudi::fused_add_rms_norm";
 const std::string kDynamicQuantSchema = "triton_gaudi::dynamic_quant";
+const std::string kSiluAndMulDynamicQuantSchema =
+    "triton_gaudi::silu_and_mul_dynamic_quant";
 const std::string kSiluAndMulSchema = "triton_gaudi::silu_and_mul";
 const std::string kGdnDecodePackedSchema =
     "triton_gaudi::gdn_decode_packed";
@@ -277,6 +279,117 @@ std::tuple<at::Tensor, at::Tensor> dynamic_quant_meta(
 }
 
 const bool kDynamicQuantRegistered = register_dynamic_quant();
+
+void validate_silu_and_mul_dynamic_quant_input(
+    const at::Tensor& input,
+    std::int64_t block_size,
+    std::int64_t n_cols,
+    std::int64_t rows) {
+  TORCH_CHECK(
+      input.scalar_type() == at::kBFloat16,
+      "Triton Gaudi fused SiLU-and-mul dynamic quantization requires BF16 input");
+  TORCH_CHECK(
+      block_size >= 128 && block_size <= 8192 &&
+          (block_size & (block_size - 1)) == 0 && n_cols > 0 &&
+          n_cols <= 4096 && n_cols <= block_size &&
+          (n_cols == 1 || n_cols > block_size / 2),
+      "Triton Gaudi fused SiLU-and-mul dynamic quantization has invalid specialization metadata");
+  TORCH_CHECK(
+      rows > 0 &&
+          rows <= static_cast<std::int64_t>(
+                      std::numeric_limits<std::uint32_t>::max()) &&
+          rows <= std::numeric_limits<std::int64_t>::max() / (2 * n_cols) &&
+          input.is_contiguous() && input.dim() == 1 &&
+          input.numel() == 2 * n_cols * rows,
+      "Triton Gaudi fused SiLU-and-mul dynamic quantization received incompatible tensor storage");
+}
+
+habana::PartialOutputMetaDataVector silu_and_mul_dynamic_quant_output_meta(
+    const at::Stack& inputs) {
+  const auto& input = inputs.at(0).toTensor();
+  const auto n_cols = inputs.at(3).toInt();
+  const auto rows = inputs.at(4).toInt();
+  validate_silu_and_mul_dynamic_quant_input(
+      input, inputs.at(2).toInt(), n_cols, rows);
+  // The fixed-GUID perf-library ABI is flattened. Callers can restore the
+  // logical [rows, n_cols] view without a copy after graph execution.
+  habana::PartialOutputMetaData quantized{
+      at::kFloat8_e4m3fn, {rows * n_cols}};
+  habana::PartialOutputMetaData scale{at::kFloat, {rows}};
+  return {quantized, scale};
+}
+
+std::shared_ptr<void> fill_silu_and_mul_dynamic_quant_params(
+    const at::Stack& inputs,
+    std::size_t& size) {
+  const auto& input = inputs.at(0).toTensor();
+  const std::string artifact_hash = inputs.at(1).toStringRef();
+  const auto block_size = inputs.at(2).toInt();
+  const auto n_cols = inputs.at(3).toInt();
+  const auto rows = inputs.at(4).toInt();
+  validate_silu_and_mul_dynamic_quant_input(
+      input, block_size, n_cols, rows);
+  TORCH_CHECK(
+      is_lower_hex_hash(artifact_hash),
+      "Triton Gaudi fused SiLU-and-mul dynamic quantization received an invalid artifact hash");
+
+  HPU_PARAMS_STUB(habana::triton_gaudi::LaunchParamsV1);
+  params->input_count = 1;
+  params->output_count = 2;
+  params->scalar_count = 0;
+  params->index_space_rank = 1;
+  params->block_size = static_cast<std::uint32_t>(block_size);
+  params->logical_size = static_cast<std::uint32_t>(n_cols);
+  params->tensor_dtype = 1U << 5;
+  params->kernel_kind =
+      habana::triton_gaudi::KernelKind::SiluAndMulDynamicQuant;
+  params->grid[0] = static_cast<std::uint64_t>(rows);
+  std::copy(
+      artifact_hash.begin(),
+      artifact_hash.end(),
+      params->artifact_hash.begin());
+  return params;
+}
+
+bool register_silu_and_mul_dynamic_quant() {
+  habana::custom_op::registerUserCustomOp(
+      kSiluAndMulDynamicQuantSchema,
+      habana::triton_gaudi::kKernelGuid,
+      silu_and_mul_dynamic_quant_output_meta,
+      fill_silu_and_mul_dynamic_quant_params);
+  return true;
+}
+
+std::tuple<at::Tensor, at::Tensor> silu_and_mul_dynamic_quant(
+    const at::Tensor& input,
+    const std::string& artifact_hash,
+    std::int64_t block_size,
+    std::int64_t n_cols,
+    std::int64_t rows) {
+  auto descriptor =
+      habana::custom_op::UserCustomOpDescriptor::getUserCustomOpDescriptor(
+          kSiluAndMulDynamicQuantSchema);
+  std::vector<c10::IValue> inputs{
+      input, artifact_hash, block_size, n_cols, rows};
+  auto outputs = descriptor.execute(inputs);
+  return {outputs.at(0), outputs.at(1)};
+}
+
+std::tuple<at::Tensor, at::Tensor> silu_and_mul_dynamic_quant_meta(
+    const at::Tensor& input,
+    const std::string&,
+    std::int64_t,
+    std::int64_t n_cols,
+    std::int64_t rows) {
+  return {
+      at::empty(
+          {rows * n_cols}, input.options().dtype(at::kFloat8_e4m3fn)),
+      at::empty({rows}, input.options().dtype(at::kFloat)),
+  };
+}
+
+const bool kSiluAndMulDynamicQuantRegistered =
+    register_silu_and_mul_dynamic_quant();
 
 void validate_silu_and_mul_input(
     const at::Tensor& input,
@@ -995,6 +1108,9 @@ TORCH_LIBRARY_FRAGMENT(triton_gaudi, module) {
       "dynamic_quant(Tensor input, str artifact_hash, int block_size, "
       "int n_cols, int rows) -> (Tensor, Tensor)");
   module.def(
+      "silu_and_mul_dynamic_quant(Tensor input, str artifact_hash, "
+      "int block_size, int n_cols, int rows) -> (Tensor, Tensor)");
+  module.def(
       "silu_and_mul(Tensor input, str artifact_hash, int block_size, "
       "int n_cols, int rows) -> Tensor");
   module.def(
@@ -1021,6 +1137,9 @@ TORCH_LIBRARY_FRAGMENT(triton_gaudi, module) {
 TORCH_LIBRARY_IMPL(triton_gaudi, HPU, module) {
   module.impl("fused_add_rms_norm", fused_add_rms_norm);
   module.impl("dynamic_quant", dynamic_quant);
+  module.impl(
+      "silu_and_mul_dynamic_quant",
+      silu_and_mul_dynamic_quant);
   module.impl("silu_and_mul", silu_and_mul);
   module.impl("gdn_decode_packed", gdn_decode_packed);
   module.impl("gdn_decode_conv_packed", gdn_decode_conv_packed);
@@ -1033,6 +1152,9 @@ TORCH_LIBRARY_IMPL(triton_gaudi, HPU, module) {
 TORCH_LIBRARY_IMPL(triton_gaudi, Meta, module) {
   module.impl("fused_add_rms_norm", fused_add_rms_norm_meta);
   module.impl("dynamic_quant", dynamic_quant_meta);
+  module.impl(
+      "silu_and_mul_dynamic_quant",
+      silu_and_mul_dynamic_quant_meta);
   module.impl("silu_and_mul", silu_and_mul_meta);
   module.impl("gdn_decode_packed", gdn_decode_packed_meta);
   module.impl("gdn_decode_conv_packed", gdn_decode_conv_packed_meta);

--- a/backend/triton_gaudi_custom_op.cpp
+++ b/backend/triton_gaudi_custom_op.cpp
@@ -23,6 +23,7 @@
 namespace {
 
 const std::string kFusedAddRmsNormSchema = "triton_gaudi::fused_add_rms_norm";
+const std::string kDynamicQuantSchema = "triton_gaudi::dynamic_quant";
 const std::string kSiluAndMulSchema = "triton_gaudi::silu_and_mul";
 const std::string kGdnDecodePackedSchema =
     "triton_gaudi::gdn_decode_packed";
@@ -173,6 +174,109 @@ std::tuple<at::Tensor, at::Tensor> fused_add_rms_norm_meta(
 }
 
 const bool kFusedAddRmsNormRegistered = register_fused_add_rms_norm();
+
+void validate_dynamic_quant_input(
+    const at::Tensor& input,
+    std::int64_t block_size,
+    std::int64_t n_cols,
+    std::int64_t rows) {
+  TORCH_CHECK(
+      input.scalar_type() == at::kBFloat16,
+      "Triton Gaudi dynamic quantization requires a BF16 input tensor");
+  TORCH_CHECK(
+      block_size > 0 && block_size <= 16384 &&
+          (block_size & (block_size - 1)) == 0 && n_cols > 0 &&
+          n_cols <= block_size && (n_cols == 1 || n_cols > block_size / 2),
+      "Triton Gaudi dynamic quantization has invalid specialization metadata");
+  TORCH_CHECK(
+      rows > 0 &&
+          rows <= static_cast<std::int64_t>(
+                      std::numeric_limits<std::uint32_t>::max()) &&
+          rows <= std::numeric_limits<std::int64_t>::max() / n_cols &&
+          input.is_contiguous() && input.dim() == 1 && input.numel() > 0 &&
+          input.numel() == n_cols * rows,
+      "Triton Gaudi dynamic quantization received incompatible tensor storage");
+}
+
+habana::PartialOutputMetaDataVector dynamic_quant_output_meta(
+    const at::Stack& inputs) {
+  const auto& input = inputs.at(0).toTensor();
+  const auto n_cols = inputs.at(3).toInt();
+  const auto rows = inputs.at(4).toInt();
+  validate_dynamic_quant_input(input, inputs.at(2).toInt(), n_cols, rows);
+  habana::PartialOutputMetaData quantized{
+      at::kFloat8_e4m3fn, input.sizes().vec()};
+  habana::PartialOutputMetaData scale{at::kFloat, {rows}};
+  return {quantized, scale};
+}
+
+std::shared_ptr<void> fill_dynamic_quant_params(
+    const at::Stack& inputs,
+    std::size_t& size) {
+  const auto& input = inputs.at(0).toTensor();
+  const std::string artifact_hash = inputs.at(1).toStringRef();
+  const auto block_size = inputs.at(2).toInt();
+  const auto n_cols = inputs.at(3).toInt();
+  const auto rows = inputs.at(4).toInt();
+  validate_dynamic_quant_input(input, block_size, n_cols, rows);
+  TORCH_CHECK(
+      is_lower_hex_hash(artifact_hash),
+      "Triton Gaudi dynamic quantization received an invalid artifact hash");
+
+  HPU_PARAMS_STUB(habana::triton_gaudi::LaunchParamsV1);
+  params->input_count = 1;
+  params->output_count = 2;
+  params->scalar_count = 0;
+  params->index_space_rank = 1;
+  params->block_size = static_cast<std::uint32_t>(block_size);
+  params->logical_size = static_cast<std::uint32_t>(n_cols);
+  params->tensor_dtype = 1U << 5; // manifest primary/output dtype is E4M3
+  params->kernel_kind = habana::triton_gaudi::KernelKind::DynamicQuant;
+  params->grid[0] = static_cast<std::uint64_t>(rows);
+  std::copy(
+      artifact_hash.begin(),
+      artifact_hash.end(),
+      params->artifact_hash.begin());
+  return params;
+}
+
+bool register_dynamic_quant() {
+  habana::custom_op::registerUserCustomOp(
+      kDynamicQuantSchema,
+      habana::triton_gaudi::kKernelGuid,
+      dynamic_quant_output_meta,
+      fill_dynamic_quant_params);
+  return true;
+}
+
+std::tuple<at::Tensor, at::Tensor> dynamic_quant(
+    const at::Tensor& input,
+    const std::string& artifact_hash,
+    std::int64_t block_size,
+    std::int64_t n_cols,
+    std::int64_t rows) {
+  auto descriptor =
+      habana::custom_op::UserCustomOpDescriptor::getUserCustomOpDescriptor(
+          kDynamicQuantSchema);
+  std::vector<c10::IValue> inputs{
+      input, artifact_hash, block_size, n_cols, rows};
+  auto outputs = descriptor.execute(inputs);
+  return {outputs.at(0), outputs.at(1)};
+}
+
+std::tuple<at::Tensor, at::Tensor> dynamic_quant_meta(
+    const at::Tensor& input,
+    const std::string&,
+    std::int64_t,
+    std::int64_t,
+    std::int64_t rows) {
+  return {
+      at::empty_like(input, input.options().dtype(at::kFloat8_e4m3fn)),
+      at::empty({rows}, input.options().dtype(at::kFloat)),
+  };
+}
+
+const bool kDynamicQuantRegistered = register_dynamic_quant();
 
 void validate_silu_and_mul_input(
     const at::Tensor& input,
@@ -888,6 +992,9 @@ TORCH_LIBRARY_FRAGMENT(triton_gaudi, module) {
       "str artifact_hash, int block_size, int n_cols, int rows, float epsilon) "
       "-> (Tensor, Tensor)");
   module.def(
+      "dynamic_quant(Tensor input, str artifact_hash, int block_size, "
+      "int n_cols, int rows) -> (Tensor, Tensor)");
+  module.def(
       "silu_and_mul(Tensor input, str artifact_hash, int block_size, "
       "int n_cols, int rows) -> Tensor");
   module.def(
@@ -913,6 +1020,7 @@ TORCH_LIBRARY_FRAGMENT(triton_gaudi, module) {
 
 TORCH_LIBRARY_IMPL(triton_gaudi, HPU, module) {
   module.impl("fused_add_rms_norm", fused_add_rms_norm);
+  module.impl("dynamic_quant", dynamic_quant);
   module.impl("silu_and_mul", silu_and_mul);
   module.impl("gdn_decode_packed", gdn_decode_packed);
   module.impl("gdn_decode_conv_packed", gdn_decode_conv_packed);
@@ -924,6 +1032,7 @@ TORCH_LIBRARY_IMPL(triton_gaudi, HPU, module) {
 
 TORCH_LIBRARY_IMPL(triton_gaudi, Meta, module) {
   module.impl("fused_add_rms_norm", fused_add_rms_norm_meta);
+  module.impl("dynamic_quant", dynamic_quant_meta);
   module.impl("silu_and_mul", silu_and_mul_meta);
   module.impl("gdn_decode_packed", gdn_decode_packed_meta);
   module.impl("gdn_decode_conv_packed", gdn_decode_conv_packed_meta);

--- a/backend/triton_gaudi_custom_op.cpp
+++ b/backend/triton_gaudi_custom_op.cpp
@@ -1,0 +1,934 @@
+/**
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/core/stack.h>
+#include <torch/library.h>
+
+#include <algorithm>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "include/habanalabs/hpu_custom_op_pt2.h"
+#include "include/habanalabs/triton_gaudi_launch.h"
+
+namespace {
+
+const std::string kFusedAddRmsNormSchema = "triton_gaudi::fused_add_rms_norm";
+const std::string kSiluAndMulSchema = "triton_gaudi::silu_and_mul";
+const std::string kGdnDecodePackedSchema =
+    "triton_gaudi::gdn_decode_packed";
+const std::string kGdnDecodeConvPackedSchema =
+    "triton_gaudi::gdn_decode_conv_packed";
+const std::string kGdnQkConvPackedSchema =
+    "triton_gaudi::gdn_qk_conv_packed";
+const std::string kGdnDecodeValueConvPackedSchema =
+    "triton_gaudi::gdn_decode_value_conv_packed";
+
+bool is_lower_hex_hash(const std::string& hash) {
+  return hash.size() == habana::triton_gaudi::kArtifactHashChars &&
+      std::all_of(hash.begin(), hash.end(), [](char value) {
+        return (value >= '0' && value <= '9') ||
+            (value >= 'a' && value <= 'f');
+      });
+}
+
+void validate_inputs(
+    const at::Tensor& hidden_states,
+    const at::Tensor& residual,
+    const at::Tensor& weight,
+    std::int64_t block_size,
+    std::int64_t n_cols) {
+  TORCH_CHECK(
+      hidden_states.scalar_type() == at::kBFloat16 &&
+          residual.scalar_type() == at::kBFloat16 &&
+          weight.scalar_type() == at::kBFloat16,
+      "Triton Gaudi fused add+RMSNorm requires BF16 tensors");
+  TORCH_CHECK(
+      hidden_states.sizes() == residual.sizes() &&
+          hidden_states.numel() > 0 && n_cols > 0 &&
+          hidden_states.numel() % n_cols == 0 && weight.dim() == 1 &&
+          weight.numel() == n_cols,
+      "Triton Gaudi fused add+RMSNorm received incompatible tensor shapes");
+  TORCH_CHECK(
+      hidden_states.is_contiguous() && residual.is_contiguous() &&
+          weight.is_contiguous(),
+      "Triton Gaudi fused add+RMSNorm requires contiguous tensors");
+  TORCH_CHECK(
+      block_size > 0 && block_size <= 8192 &&
+          (block_size & (block_size - 1)) == 0 && n_cols <= block_size &&
+          (n_cols == 1 || n_cols > block_size / 2),
+      "Triton Gaudi fused add+RMSNorm has invalid specialization metadata");
+}
+
+habana::PartialOutputMetaDataVector output_meta(const at::Stack& inputs) {
+  const auto& hidden_states = inputs.at(0).toTensor();
+  const auto& residual = inputs.at(1).toTensor();
+  const auto& weight = inputs.at(2).toTensor();
+  validate_inputs(
+      hidden_states,
+      residual,
+      weight,
+      inputs.at(4).toInt(),
+      inputs.at(5).toInt());
+  TORCH_CHECK(
+      inputs.at(6).toInt() == hidden_states.numel() / inputs.at(5).toInt(),
+      "Triton Gaudi fused add+RMSNorm row specialization is inconsistent");
+  habana::PartialOutputMetaData output{
+      hidden_states.scalar_type(), hidden_states.sizes().vec()};
+  habana::PartialOutputMetaData residual_output{
+      residual.scalar_type(), residual.sizes().vec()};
+  return {output, residual_output};
+}
+
+std::shared_ptr<void> fill_params(const at::Stack& inputs, std::size_t& size) {
+  const auto& hidden_states = inputs.at(0).toTensor();
+  const auto& residual = inputs.at(1).toTensor();
+  const auto& weight = inputs.at(2).toTensor();
+  const std::string artifact_hash = inputs.at(3).toStringRef();
+  const auto block_size = inputs.at(4).toInt();
+  const auto n_cols = inputs.at(5).toInt();
+  const auto rows = inputs.at(6).toInt();
+  validate_inputs(hidden_states, residual, weight, block_size, n_cols);
+  TORCH_CHECK(
+      is_lower_hex_hash(artifact_hash),
+      "Triton Gaudi fused add+RMSNorm received an invalid artifact hash");
+
+  TORCH_CHECK(
+      rows == hidden_states.numel() / n_cols && rows > 0 &&
+          rows <= static_cast<std::int64_t>(
+                      std::numeric_limits<std::uint32_t>::max()),
+      "Triton Gaudi fused add+RMSNorm index space is out of range");
+
+  HPU_PARAMS_STUB(habana::triton_gaudi::LaunchParamsV1);
+  params->input_count = 3;
+  params->output_count = 2;
+  params->scalar_count = 1;
+  params->index_space_rank = 1;
+  params->block_size = static_cast<std::uint32_t>(block_size);
+  params->logical_size = static_cast<std::uint32_t>(n_cols);
+  params->tensor_dtype = 1U << 8; // tpc_lib_api::DATA_BF16
+  params->kernel_kind = habana::triton_gaudi::KernelKind::FusedAddRmsNorm;
+  params->grid[0] = static_cast<std::uint64_t>(rows);
+  const float epsilon = static_cast<float>(inputs.at(7).toDouble());
+  std::memcpy(&params->scalar_params[0], &epsilon, sizeof(epsilon));
+  std::copy(
+      artifact_hash.begin(),
+      artifact_hash.end(),
+      params->artifact_hash.begin());
+  return params;
+}
+
+bool register_fused_add_rms_norm() {
+  habana::custom_op::registerUserCustomOp(
+      kFusedAddRmsNormSchema,
+      habana::triton_gaudi::kKernelGuid,
+      output_meta,
+      fill_params);
+  return true;
+}
+
+std::tuple<at::Tensor, at::Tensor> fused_add_rms_norm(
+    const at::Tensor& hidden_states,
+    const at::Tensor& residual,
+    const at::Tensor& weight,
+    const std::string& artifact_hash,
+    std::int64_t block_size,
+    std::int64_t n_cols,
+    std::int64_t rows,
+    double epsilon) {
+  auto descriptor = habana::custom_op::UserCustomOpDescriptor::
+      getUserCustomOpDescriptor(kFusedAddRmsNormSchema);
+  std::vector<c10::IValue> inputs{
+      hidden_states,
+      residual,
+      weight,
+      artifact_hash,
+      block_size,
+      n_cols,
+      rows,
+      epsilon};
+  auto outputs = descriptor.execute(inputs);
+  return {outputs.at(0), outputs.at(1)};
+}
+
+std::tuple<at::Tensor, at::Tensor> fused_add_rms_norm_meta(
+    const at::Tensor& hidden_states,
+    const at::Tensor& residual,
+    const at::Tensor&,
+    const std::string&,
+    std::int64_t,
+    std::int64_t,
+    std::int64_t,
+    double) {
+  return {at::empty_like(hidden_states), at::empty_like(residual)};
+}
+
+const bool kFusedAddRmsNormRegistered = register_fused_add_rms_norm();
+
+void validate_silu_and_mul_input(
+    const at::Tensor& input,
+    std::int64_t block_size,
+    std::int64_t n_cols,
+    std::int64_t rows) {
+  TORCH_CHECK(
+      input.scalar_type() == at::kBFloat16,
+      "Triton Gaudi SiLU-and-mul requires a BF16 input tensor");
+  TORCH_CHECK(
+      input.is_contiguous() && input.numel() > 0 && n_cols > 0 && rows > 0 &&
+          input.dim() == 2 && input.size(0) == rows &&
+          input.size(1) == 2 * n_cols && n_cols <= 65536 &&
+          rows <= static_cast<std::int64_t>(
+                      std::numeric_limits<std::uint32_t>::max()) &&
+          input.numel() == 2 * rows * n_cols,
+      "Triton Gaudi SiLU-and-mul received incompatible tensor storage");
+  TORCH_CHECK(
+      block_size >= 128 && block_size <= 1024 &&
+          (block_size & (block_size - 1)) == 0,
+      "Triton Gaudi SiLU-and-mul has invalid specialization metadata");
+}
+
+habana::PartialOutputMetaDataVector silu_and_mul_output_meta(
+    const at::Stack& inputs) {
+  const auto& input = inputs.at(0).toTensor();
+  const auto n_cols = inputs.at(3).toInt();
+  const auto rows = inputs.at(4).toInt();
+  validate_silu_and_mul_input(
+      input, inputs.at(2).toInt(), n_cols, rows);
+  habana::PartialOutputMetaData output{
+      input.scalar_type(), {rows, n_cols}};
+  return {output};
+}
+
+std::shared_ptr<void> fill_silu_and_mul_params(
+    const at::Stack& inputs,
+    std::size_t& size) {
+  const auto& input = inputs.at(0).toTensor();
+  const std::string artifact_hash = inputs.at(1).toStringRef();
+  const auto block_size = inputs.at(2).toInt();
+  const auto n_cols = inputs.at(3).toInt();
+  const auto rows = inputs.at(4).toInt();
+  validate_silu_and_mul_input(input, block_size, n_cols, rows);
+  TORCH_CHECK(
+      is_lower_hex_hash(artifact_hash),
+      "Triton Gaudi SiLU-and-mul received an invalid artifact hash");
+
+  HPU_PARAMS_STUB(habana::triton_gaudi::LaunchParamsV1);
+  params->input_count = 1;
+  params->output_count = 1;
+  params->scalar_count = 0;
+  params->index_space_rank = 2;
+  params->block_size = static_cast<std::uint32_t>(block_size);
+  params->logical_size = static_cast<std::uint32_t>(n_cols);
+  params->tensor_dtype = 1U << 8; // tpc_lib_api::DATA_BF16
+  params->kernel_kind = habana::triton_gaudi::KernelKind::SiluAndMul;
+  params->grid[0] = static_cast<std::uint64_t>(
+      (n_cols + block_size - 1) / block_size);
+  params->grid[1] = static_cast<std::uint64_t>(rows);
+  std::copy(
+      artifact_hash.begin(),
+      artifact_hash.end(),
+      params->artifact_hash.begin());
+  return params;
+}
+
+bool register_silu_and_mul() {
+  habana::custom_op::registerUserCustomOp(
+      kSiluAndMulSchema,
+      habana::triton_gaudi::kKernelGuid,
+      silu_and_mul_output_meta,
+      fill_silu_and_mul_params);
+  return true;
+}
+
+at::Tensor silu_and_mul(
+    const at::Tensor& input,
+    const std::string& artifact_hash,
+    std::int64_t block_size,
+    std::int64_t n_cols,
+    std::int64_t rows) {
+  auto descriptor = habana::custom_op::UserCustomOpDescriptor::
+      getUserCustomOpDescriptor(kSiluAndMulSchema);
+  std::vector<c10::IValue> inputs{
+      input, artifact_hash, block_size, n_cols, rows};
+  return descriptor.execute(inputs).at(0);
+}
+
+at::Tensor silu_and_mul_meta(
+    const at::Tensor& input,
+    const std::string&,
+    std::int64_t,
+    std::int64_t n_cols,
+    std::int64_t rows) {
+  return at::empty({rows, n_cols}, input.options());
+}
+
+const bool kSiluAndMulRegistered = register_silu_and_mul();
+
+void validate_gdn_decode_packed_inputs(
+    const at::Tensor& state_cache,
+    const at::Tensor& packed_qkv,
+    const at::Tensor& gate_a,
+    const at::Tensor& gate_b,
+    const at::Tensor& a_log,
+    const at::Tensor& dt_bias,
+    const at::Tensor& state_indices,
+    std::int64_t value_tile) {
+  TORCH_CHECK(
+      state_cache.scalar_type() == at::kFloat &&
+          packed_qkv.scalar_type() == at::kBFloat16 &&
+          gate_a.scalar_type() == at::kBFloat16 &&
+          gate_b.scalar_type() == at::kBFloat16 &&
+          a_log.scalar_type() == at::kFloat &&
+          dt_bias.scalar_type() == at::kFloat &&
+          state_indices.scalar_type() == at::kInt,
+      "Triton Gaudi packed GDN decode requires the canonical mixed dtypes");
+  TORCH_CHECK(
+      state_cache.dim() == 4 && state_cache.size(0) > 0 &&
+          state_cache.size(1) == 48 && state_cache.size(2) == 128 &&
+          state_cache.size(3) == 128 && packed_qkv.dim() == 2 &&
+          packed_qkv.size(0) > 0 && packed_qkv.size(1) == 10240,
+      "Triton Gaudi packed GDN decode requires Qwen3.5 state and packed QKV shapes");
+  const auto batch = packed_qkv.size(0);
+  TORCH_CHECK(
+      gate_a.sizes() == at::IntArrayRef({batch, 48}) &&
+          gate_b.sizes() == gate_a.sizes() &&
+          a_log.sizes() == at::IntArrayRef({48}) &&
+          dt_bias.sizes() == at::IntArrayRef({48}) &&
+          state_indices.sizes() == at::IntArrayRef({batch}),
+      "Triton Gaudi packed GDN decode received incompatible gate or index shapes");
+  TORCH_CHECK(
+      state_cache.is_contiguous() && packed_qkv.is_contiguous() &&
+          gate_a.is_contiguous() && gate_b.is_contiguous() &&
+          a_log.is_contiguous() && dt_bias.is_contiguous() &&
+          state_indices.is_contiguous(),
+      "Triton Gaudi packed GDN decode requires contiguous tensors");
+  TORCH_CHECK(
+      value_tile == 16 || value_tile == 32 || value_tile == 64 ||
+          value_tile == 128,
+      "Triton Gaudi packed GDN decode VALUE_TILE must be 16, 32, 64, or 128");
+  TORCH_CHECK(
+      state_cache.size(0) <=
+          static_cast<std::int64_t>(std::numeric_limits<std::uint32_t>::max()) &&
+          batch <=
+              static_cast<std::int64_t>(std::numeric_limits<std::uint32_t>::max()),
+      "Triton Gaudi packed GDN decode geometry exceeds the launch ABI");
+}
+
+habana::PartialOutputMetaDataVector gdn_decode_packed_output_meta(
+    const at::Stack& inputs) {
+  const auto& state_cache = inputs.at(0).toTensor();
+  const auto& packed_qkv = inputs.at(1).toTensor();
+  validate_gdn_decode_packed_inputs(
+      state_cache,
+      packed_qkv,
+      inputs.at(2).toTensor(),
+      inputs.at(3).toTensor(),
+      inputs.at(4).toTensor(),
+      inputs.at(5).toTensor(),
+      inputs.at(6).toTensor(),
+      inputs.at(8).toInt());
+  return {{at::kBFloat16, {packed_qkv.size(0), 48, 128}}};
+}
+
+std::shared_ptr<void> fill_gdn_decode_packed_params(
+    const at::Stack& inputs,
+    std::size_t& size) {
+  const auto& state_cache = inputs.at(0).toTensor();
+  const auto& packed_qkv = inputs.at(1).toTensor();
+  const std::string artifact_hash = inputs.at(7).toStringRef();
+  const auto value_tile = inputs.at(8).toInt();
+  validate_gdn_decode_packed_inputs(
+      state_cache,
+      packed_qkv,
+      inputs.at(2).toTensor(),
+      inputs.at(3).toTensor(),
+      inputs.at(4).toTensor(),
+      inputs.at(5).toTensor(),
+      inputs.at(6).toTensor(),
+      value_tile);
+  TORCH_CHECK(
+      is_lower_hex_hash(artifact_hash),
+      "Triton Gaudi packed GDN decode received an invalid artifact hash");
+
+  HPU_PARAMS_STUB(habana::triton_gaudi::LaunchParamsV1);
+  params->input_count = 7;
+  params->output_count = 1;
+  params->scalar_count = 1;
+  params->index_space_rank = 3;
+  params->block_size = static_cast<std::uint32_t>(value_tile);
+  params->logical_size = 128;
+  params->tensor_dtype = 1U << 8; // primary/output dtype is BF16
+  params->kernel_kind =
+      habana::triton_gaudi::KernelKind::GdnDecodePacked;
+  params->grid[0] = static_cast<std::uint64_t>(128 / value_tile);
+  params->grid[1] = 48;
+  params->grid[2] = static_cast<std::uint64_t>(packed_qkv.size(0));
+  params->scalar_params[0] =
+      static_cast<std::uint32_t>(state_cache.size(0));
+  std::copy(
+      artifact_hash.begin(),
+      artifact_hash.end(),
+      params->artifact_hash.begin());
+  return params;
+}
+
+bool register_gdn_decode_packed() {
+  habana::custom_op::registerUserCustomOp(
+      kGdnDecodePackedSchema,
+      habana::triton_gaudi::kKernelGuid,
+      gdn_decode_packed_output_meta,
+      fill_gdn_decode_packed_params);
+  return true;
+}
+
+at::Tensor gdn_decode_packed(
+    at::Tensor& state_cache,
+    const at::Tensor& packed_qkv,
+    const at::Tensor& gate_a,
+    const at::Tensor& gate_b,
+    const at::Tensor& a_log,
+    const at::Tensor& dt_bias,
+    const at::Tensor& state_indices,
+    const std::string& artifact_hash,
+    std::int64_t value_tile) {
+  auto descriptor = habana::custom_op::UserCustomOpDescriptor::
+      getUserCustomOpDescriptor(kGdnDecodePackedSchema);
+  std::vector<c10::IValue> inputs{
+      state_cache,
+      packed_qkv,
+      gate_a,
+      gate_b,
+      a_log,
+      dt_bias,
+      state_indices,
+      artifact_hash,
+      value_tile};
+  return descriptor.execute(inputs).at(0);
+}
+
+at::Tensor gdn_decode_packed_meta(
+    at::Tensor&,
+    const at::Tensor& packed_qkv,
+    const at::Tensor&,
+    const at::Tensor&,
+    const at::Tensor&,
+    const at::Tensor&,
+    const at::Tensor&,
+    const std::string&,
+    std::int64_t) {
+  return at::empty(
+      {packed_qkv.size(0), 48, 128},
+      packed_qkv.options().dtype(at::kBFloat16));
+}
+
+const bool kGdnDecodePackedRegistered = register_gdn_decode_packed();
+
+void validate_gdn_decode_conv_packed_inputs(
+    const at::Tensor& conv_state,
+    const at::Tensor& state_cache,
+    const at::Tensor& packed_qkv,
+    const at::Tensor& gate_a,
+    const at::Tensor& gate_b,
+    const at::Tensor& a_log,
+    const at::Tensor& dt_bias,
+    const at::Tensor& state_indices,
+    const at::Tensor& conv_weight_t) {
+  TORCH_CHECK(
+      conv_state.scalar_type() == at::kBFloat16 &&
+          state_cache.scalar_type() == at::kFloat &&
+          packed_qkv.scalar_type() == at::kBFloat16 &&
+          gate_a.scalar_type() == at::kBFloat16 &&
+          gate_b.scalar_type() == at::kBFloat16 &&
+          a_log.scalar_type() == at::kFloat &&
+          dt_bias.scalar_type() == at::kFloat &&
+          state_indices.scalar_type() == at::kInt &&
+          conv_weight_t.scalar_type() == at::kBFloat16,
+      "Triton Gaudi fused conv+GDN requires the canonical mixed dtypes");
+  TORCH_CHECK(
+      conv_state.dim() == 3 && conv_state.size(0) > 0 &&
+          conv_state.size(1) == 3 && conv_state.size(2) == 10240 &&
+          state_cache.dim() == 4 && state_cache.size(0) > 0 &&
+          state_cache.size(1) == 48 && state_cache.size(2) == 128 &&
+          state_cache.size(3) == 128 && packed_qkv.dim() == 2 &&
+          packed_qkv.size(0) > 0 && packed_qkv.size(1) == 10240,
+      "Triton Gaudi fused conv+GDN requires Qwen3.5 cache and packed QKV shapes");
+  const auto batch = packed_qkv.size(0);
+  TORCH_CHECK(
+      gate_a.sizes() == at::IntArrayRef({batch, 48}) &&
+          gate_b.sizes() == gate_a.sizes() &&
+          a_log.sizes() == at::IntArrayRef({48}) &&
+          dt_bias.sizes() == at::IntArrayRef({48}) &&
+          state_indices.sizes() == at::IntArrayRef({batch}) &&
+          conv_weight_t.sizes() == at::IntArrayRef({4, 10240}),
+      "Triton Gaudi fused conv+GDN received incompatible weights, gates, or indices");
+  TORCH_CHECK(
+      conv_state.is_contiguous() && state_cache.is_contiguous() &&
+          packed_qkv.is_contiguous() && gate_a.is_contiguous() &&
+          gate_b.is_contiguous() && a_log.is_contiguous() &&
+          dt_bias.is_contiguous() && state_indices.is_contiguous() &&
+          conv_weight_t.is_contiguous(),
+      "Triton Gaudi fused conv+GDN requires contiguous tensors");
+  TORCH_CHECK(
+      conv_state.size(0) <=
+              static_cast<std::int64_t>(
+                  std::numeric_limits<std::uint32_t>::max()) &&
+          state_cache.size(0) <=
+              static_cast<std::int64_t>(
+                  std::numeric_limits<std::uint32_t>::max()) &&
+          batch <=
+              static_cast<std::int64_t>(
+                  std::numeric_limits<std::uint32_t>::max()),
+      "Triton Gaudi fused conv+GDN geometry exceeds the launch ABI");
+}
+
+habana::PartialOutputMetaDataVector gdn_decode_conv_packed_output_meta(
+    const at::Stack& inputs) {
+  const auto& packed_qkv = inputs.at(2).toTensor();
+  validate_gdn_decode_conv_packed_inputs(
+      inputs.at(0).toTensor(),
+      inputs.at(1).toTensor(),
+      packed_qkv,
+      inputs.at(3).toTensor(),
+      inputs.at(4).toTensor(),
+      inputs.at(5).toTensor(),
+      inputs.at(6).toTensor(),
+      inputs.at(7).toTensor(),
+      inputs.at(8).toTensor());
+  return {{at::kBFloat16, {packed_qkv.size(0), 48, 128}}};
+}
+
+std::shared_ptr<void> fill_gdn_decode_conv_packed_params(
+    const at::Stack& inputs,
+    std::size_t& size) {
+  const auto& conv_state = inputs.at(0).toTensor();
+  const auto& state_cache = inputs.at(1).toTensor();
+  const auto& packed_qkv = inputs.at(2).toTensor();
+  const std::string artifact_hash = inputs.at(9).toStringRef();
+  validate_gdn_decode_conv_packed_inputs(
+      conv_state,
+      state_cache,
+      packed_qkv,
+      inputs.at(3).toTensor(),
+      inputs.at(4).toTensor(),
+      inputs.at(5).toTensor(),
+      inputs.at(6).toTensor(),
+      inputs.at(7).toTensor(),
+      inputs.at(8).toTensor());
+  TORCH_CHECK(
+      is_lower_hex_hash(artifact_hash),
+      "Triton Gaudi fused conv+GDN received an invalid artifact hash");
+
+  HPU_PARAMS_STUB(habana::triton_gaudi::LaunchParamsV1);
+  params->input_count = 9;
+  params->output_count = 1;
+  params->scalar_count = 2;
+  params->index_space_rank = 2;
+  params->block_size = 128;
+  params->logical_size = 128;
+  params->tensor_dtype = 1U << 8; // primary/output dtype is BF16
+  params->kernel_kind =
+      habana::triton_gaudi::KernelKind::GdnDecodeConvPacked;
+  params->grid[0] = 16;
+  params->grid[1] = static_cast<std::uint64_t>(packed_qkv.size(0));
+  params->scalar_params[0] =
+      static_cast<std::uint32_t>(conv_state.size(0));
+  params->scalar_params[1] =
+      static_cast<std::uint32_t>(state_cache.size(0));
+  std::copy(
+      artifact_hash.begin(),
+      artifact_hash.end(),
+      params->artifact_hash.begin());
+  return params;
+}
+
+bool register_gdn_decode_conv_packed() {
+  habana::custom_op::registerUserCustomOp(
+      kGdnDecodeConvPackedSchema,
+      habana::triton_gaudi::kKernelGuid,
+      gdn_decode_conv_packed_output_meta,
+      fill_gdn_decode_conv_packed_params);
+  return true;
+}
+
+at::Tensor gdn_decode_conv_packed(
+    at::Tensor& conv_state,
+    at::Tensor& state_cache,
+    const at::Tensor& packed_qkv,
+    const at::Tensor& gate_a,
+    const at::Tensor& gate_b,
+    const at::Tensor& a_log,
+    const at::Tensor& dt_bias,
+    const at::Tensor& state_indices,
+    const at::Tensor& conv_weight_t,
+    const std::string& artifact_hash) {
+  auto descriptor = habana::custom_op::UserCustomOpDescriptor::
+      getUserCustomOpDescriptor(kGdnDecodeConvPackedSchema);
+  std::vector<c10::IValue> inputs{
+      conv_state,
+      state_cache,
+      packed_qkv,
+      gate_a,
+      gate_b,
+      a_log,
+      dt_bias,
+      state_indices,
+      conv_weight_t,
+      artifact_hash};
+  return descriptor.execute(inputs).at(0);
+}
+
+at::Tensor gdn_decode_conv_packed_meta(
+    at::Tensor&,
+    at::Tensor&,
+    const at::Tensor& packed_qkv,
+    const at::Tensor&,
+    const at::Tensor&,
+    const at::Tensor&,
+    const at::Tensor&,
+    const at::Tensor&,
+    const at::Tensor&,
+    const std::string&) {
+  return at::empty(
+      {packed_qkv.size(0), 48, 128},
+      packed_qkv.options().dtype(at::kBFloat16));
+}
+
+const bool kGdnDecodeConvPackedRegistered =
+    register_gdn_decode_conv_packed();
+
+void validate_gdn_qk_conv_packed_inputs(
+    const at::Tensor& conv_state,
+    const at::Tensor& packed_qkv,
+    const at::Tensor& state_indices,
+    const at::Tensor& conv_weight_t) {
+  TORCH_CHECK(
+      conv_state.scalar_type() == at::kBFloat16 &&
+          packed_qkv.scalar_type() == at::kBFloat16 &&
+          state_indices.scalar_type() == at::kInt &&
+          conv_weight_t.scalar_type() == at::kBFloat16,
+      "Triton Gaudi packed Q/K convolution requires BF16 data and i32 indices");
+  TORCH_CHECK(
+      conv_state.dim() == 3 && conv_state.size(0) > 0 &&
+          conv_state.size(1) == 3 && conv_state.size(2) == 10240 &&
+          packed_qkv.dim() == 2 && packed_qkv.size(0) > 0 &&
+          packed_qkv.size(1) == 10240 &&
+          state_indices.sizes() == at::IntArrayRef({packed_qkv.size(0)}) &&
+          conv_weight_t.sizes() == at::IntArrayRef({4, 10240}),
+      "Triton Gaudi packed Q/K convolution received incompatible shapes");
+  TORCH_CHECK(
+      conv_state.is_contiguous() && packed_qkv.is_contiguous() &&
+          state_indices.is_contiguous() && conv_weight_t.is_contiguous(),
+      "Triton Gaudi packed Q/K convolution requires contiguous tensors");
+  TORCH_CHECK(
+      conv_state.size(0) <=
+              static_cast<std::int64_t>(
+                  std::numeric_limits<std::uint32_t>::max()) &&
+          packed_qkv.size(0) <=
+              static_cast<std::int64_t>(
+                  std::numeric_limits<std::uint32_t>::max()),
+      "Triton Gaudi packed Q/K convolution geometry exceeds the launch ABI");
+}
+
+habana::PartialOutputMetaDataVector gdn_qk_conv_packed_output_meta(
+    const at::Stack& inputs) {
+  const auto& packed_qkv = inputs.at(1).toTensor();
+  validate_gdn_qk_conv_packed_inputs(
+      inputs.at(0).toTensor(),
+      packed_qkv,
+      inputs.at(2).toTensor(),
+      inputs.at(3).toTensor());
+  return {{at::kBFloat16, {packed_qkv.size(0), 4096}}};
+}
+
+std::shared_ptr<void> fill_gdn_qk_conv_packed_params(
+    const at::Stack& inputs,
+    std::size_t& size) {
+  const auto& conv_state = inputs.at(0).toTensor();
+  const auto& packed_qkv = inputs.at(1).toTensor();
+  const std::string artifact_hash = inputs.at(4).toStringRef();
+  validate_gdn_qk_conv_packed_inputs(
+      conv_state,
+      packed_qkv,
+      inputs.at(2).toTensor(),
+      inputs.at(3).toTensor());
+  TORCH_CHECK(
+      is_lower_hex_hash(artifact_hash),
+      "Triton Gaudi packed Q/K convolution received an invalid artifact hash");
+  HPU_PARAMS_STUB(habana::triton_gaudi::LaunchParamsV1);
+  params->input_count = 4;
+  params->output_count = 1;
+  params->scalar_count = 1;
+  params->index_space_rank = 2;
+  params->block_size = 128;
+  params->logical_size = 4096;
+  params->tensor_dtype = 1U << 8;
+  params->kernel_kind = habana::triton_gaudi::KernelKind::GdnQkConvPacked;
+  params->grid[0] = 32;
+  params->grid[1] = static_cast<std::uint64_t>(packed_qkv.size(0));
+  params->scalar_params[0] =
+      static_cast<std::uint32_t>(conv_state.size(0));
+  std::copy(
+      artifact_hash.begin(),
+      artifact_hash.end(),
+      params->artifact_hash.begin());
+  return params;
+}
+
+bool register_gdn_qk_conv_packed() {
+  habana::custom_op::registerUserCustomOp(
+      kGdnQkConvPackedSchema,
+      habana::triton_gaudi::kKernelGuid,
+      gdn_qk_conv_packed_output_meta,
+      fill_gdn_qk_conv_packed_params);
+  return true;
+}
+
+at::Tensor gdn_qk_conv_packed(
+    at::Tensor& conv_state,
+    const at::Tensor& packed_qkv,
+    const at::Tensor& state_indices,
+    const at::Tensor& conv_weight_t,
+    const std::string& artifact_hash) {
+  auto descriptor = habana::custom_op::UserCustomOpDescriptor::
+      getUserCustomOpDescriptor(kGdnQkConvPackedSchema);
+  std::vector<c10::IValue> inputs{
+      conv_state,
+      packed_qkv,
+      state_indices,
+      conv_weight_t,
+      artifact_hash};
+  return descriptor.execute(inputs).at(0);
+}
+
+at::Tensor gdn_qk_conv_packed_meta(
+    at::Tensor&,
+    const at::Tensor& packed_qkv,
+    const at::Tensor&,
+    const at::Tensor&,
+    const std::string&) {
+  return at::empty(
+      {packed_qkv.size(0), 4096},
+      packed_qkv.options().dtype(at::kBFloat16));
+}
+
+const bool kGdnQkConvPackedRegistered = register_gdn_qk_conv_packed();
+
+void validate_gdn_decode_value_conv_packed_inputs(
+    const at::Tensor& conv_state,
+    const at::Tensor& state_cache,
+    const at::Tensor& qk_conv,
+    const at::Tensor& packed_qkv,
+    const at::Tensor& gate_a,
+    const at::Tensor& gate_b,
+    const at::Tensor& a_log,
+    const at::Tensor& dt_bias,
+    const at::Tensor& state_indices,
+    const at::Tensor& conv_weight_t,
+    std::int64_t value_tile) {
+  validate_gdn_decode_conv_packed_inputs(
+      conv_state,
+      state_cache,
+      packed_qkv,
+      gate_a,
+      gate_b,
+      a_log,
+      dt_bias,
+      state_indices,
+      conv_weight_t);
+  TORCH_CHECK(
+      qk_conv.scalar_type() == at::kBFloat16 && qk_conv.is_contiguous() &&
+          qk_conv.sizes() == at::IntArrayRef({packed_qkv.size(0), 4096}),
+      "Triton Gaudi fused value-conv + GDN requires packed BF16 Q/K input");
+  TORCH_CHECK(
+      value_tile == 16 || value_tile == 32 || value_tile == 64 ||
+          value_tile == 128,
+      "Triton Gaudi fused value-conv + GDN has invalid VALUE_TILE");
+}
+
+habana::PartialOutputMetaDataVector
+gdn_decode_value_conv_packed_output_meta(const at::Stack& inputs) {
+  const auto& packed_qkv = inputs.at(3).toTensor();
+  validate_gdn_decode_value_conv_packed_inputs(
+      inputs.at(0).toTensor(),
+      inputs.at(1).toTensor(),
+      inputs.at(2).toTensor(),
+      packed_qkv,
+      inputs.at(4).toTensor(),
+      inputs.at(5).toTensor(),
+      inputs.at(6).toTensor(),
+      inputs.at(7).toTensor(),
+      inputs.at(8).toTensor(),
+      inputs.at(9).toTensor(),
+      inputs.at(11).toInt());
+  return {{at::kBFloat16, {packed_qkv.size(0), 48, 128}}};
+}
+
+std::shared_ptr<void> fill_gdn_decode_value_conv_packed_params(
+    const at::Stack& inputs,
+    std::size_t& size) {
+  const auto& conv_state = inputs.at(0).toTensor();
+  const auto& state_cache = inputs.at(1).toTensor();
+  const auto& packed_qkv = inputs.at(3).toTensor();
+  const std::string artifact_hash = inputs.at(10).toStringRef();
+  const auto value_tile = inputs.at(11).toInt();
+  validate_gdn_decode_value_conv_packed_inputs(
+      conv_state,
+      state_cache,
+      inputs.at(2).toTensor(),
+      packed_qkv,
+      inputs.at(4).toTensor(),
+      inputs.at(5).toTensor(),
+      inputs.at(6).toTensor(),
+      inputs.at(7).toTensor(),
+      inputs.at(8).toTensor(),
+      inputs.at(9).toTensor(),
+      value_tile);
+  TORCH_CHECK(
+      is_lower_hex_hash(artifact_hash),
+      "Triton Gaudi fused value-conv + GDN received an invalid artifact hash");
+  HPU_PARAMS_STUB(habana::triton_gaudi::LaunchParamsV1);
+  params->input_count = 10;
+  params->output_count = 1;
+  params->scalar_count = 2;
+  params->index_space_rank = 3;
+  params->block_size = static_cast<std::uint32_t>(value_tile);
+  params->logical_size = 128;
+  params->tensor_dtype = 1U << 8;
+  params->kernel_kind =
+      habana::triton_gaudi::KernelKind::GdnDecodeValueConvPacked;
+  params->grid[0] = static_cast<std::uint64_t>(128 / value_tile);
+  params->grid[1] = 48;
+  params->grid[2] = static_cast<std::uint64_t>(packed_qkv.size(0));
+  params->scalar_params[0] =
+      static_cast<std::uint32_t>(conv_state.size(0));
+  params->scalar_params[1] =
+      static_cast<std::uint32_t>(state_cache.size(0));
+  std::copy(
+      artifact_hash.begin(),
+      artifact_hash.end(),
+      params->artifact_hash.begin());
+  return params;
+}
+
+bool register_gdn_decode_value_conv_packed() {
+  habana::custom_op::registerUserCustomOp(
+      kGdnDecodeValueConvPackedSchema,
+      habana::triton_gaudi::kKernelGuid,
+      gdn_decode_value_conv_packed_output_meta,
+      fill_gdn_decode_value_conv_packed_params);
+  return true;
+}
+
+at::Tensor gdn_decode_value_conv_packed(
+    at::Tensor& conv_state,
+    at::Tensor& state_cache,
+    const at::Tensor& qk_conv,
+    const at::Tensor& packed_qkv,
+    const at::Tensor& gate_a,
+    const at::Tensor& gate_b,
+    const at::Tensor& a_log,
+    const at::Tensor& dt_bias,
+    const at::Tensor& state_indices,
+    const at::Tensor& conv_weight_t,
+    const std::string& artifact_hash,
+    std::int64_t value_tile) {
+  auto descriptor = habana::custom_op::UserCustomOpDescriptor::
+      getUserCustomOpDescriptor(kGdnDecodeValueConvPackedSchema);
+  std::vector<c10::IValue> inputs{
+      conv_state,
+      state_cache,
+      qk_conv,
+      packed_qkv,
+      gate_a,
+      gate_b,
+      a_log,
+      dt_bias,
+      state_indices,
+      conv_weight_t,
+      artifact_hash,
+      value_tile};
+  return descriptor.execute(inputs).at(0);
+}
+
+at::Tensor gdn_decode_value_conv_packed_meta(
+    at::Tensor&,
+    at::Tensor&,
+    const at::Tensor&,
+    const at::Tensor& packed_qkv,
+    const at::Tensor&,
+    const at::Tensor&,
+    const at::Tensor&,
+    const at::Tensor&,
+    const at::Tensor&,
+    const at::Tensor&,
+    const std::string&,
+    std::int64_t) {
+  return at::empty(
+      {packed_qkv.size(0), 48, 128},
+      packed_qkv.options().dtype(at::kBFloat16));
+}
+
+const bool kGdnDecodeValueConvPackedRegistered =
+    register_gdn_decode_value_conv_packed();
+
+} // namespace
+
+TORCH_LIBRARY_FRAGMENT(triton_gaudi, module) {
+  module.def(
+      "fused_add_rms_norm(Tensor hidden_states, Tensor residual, Tensor weight, "
+      "str artifact_hash, int block_size, int n_cols, int rows, float epsilon) "
+      "-> (Tensor, Tensor)");
+  module.def(
+      "silu_and_mul(Tensor input, str artifact_hash, int block_size, "
+      "int n_cols, int rows) -> Tensor");
+  module.def(
+      "gdn_decode_packed(Tensor(a!) state_cache, Tensor packed_qkv, "
+      "Tensor gate_a, Tensor gate_b, Tensor a_log, Tensor dt_bias, "
+      "Tensor state_indices, str artifact_hash, int value_tile) -> Tensor");
+  module.def(
+      "gdn_decode_conv_packed(Tensor(a!) conv_state, "
+      "Tensor(b!) state_cache, Tensor packed_qkv, Tensor gate_a, "
+      "Tensor gate_b, Tensor a_log, Tensor dt_bias, Tensor state_indices, "
+      "Tensor conv_weight_t, str artifact_hash) -> Tensor");
+  module.def(
+      "gdn_qk_conv_packed(Tensor(a!) conv_state, Tensor packed_qkv, "
+      "Tensor state_indices, Tensor conv_weight_t, str artifact_hash) "
+      "-> Tensor");
+  module.def(
+      "gdn_decode_value_conv_packed(Tensor(a!) conv_state, "
+      "Tensor(b!) state_cache, Tensor qk_conv, Tensor packed_qkv, "
+      "Tensor gate_a, Tensor gate_b, Tensor a_log, Tensor dt_bias, "
+      "Tensor state_indices, Tensor conv_weight_t, str artifact_hash, "
+      "int value_tile) -> Tensor");
+}
+
+TORCH_LIBRARY_IMPL(triton_gaudi, HPU, module) {
+  module.impl("fused_add_rms_norm", fused_add_rms_norm);
+  module.impl("silu_and_mul", silu_and_mul);
+  module.impl("gdn_decode_packed", gdn_decode_packed);
+  module.impl("gdn_decode_conv_packed", gdn_decode_conv_packed);
+  module.impl("gdn_qk_conv_packed", gdn_qk_conv_packed);
+  module.impl(
+      "gdn_decode_value_conv_packed",
+      gdn_decode_value_conv_packed);
+}
+
+TORCH_LIBRARY_IMPL(triton_gaudi, Meta, module) {
+  module.impl("fused_add_rms_norm", fused_add_rms_norm_meta);
+  module.impl("silu_and_mul", silu_and_mul_meta);
+  module.impl("gdn_decode_packed", gdn_decode_packed_meta);
+  module.impl("gdn_decode_conv_packed", gdn_decode_conv_packed_meta);
+  module.impl("gdn_qk_conv_packed", gdn_qk_conv_packed_meta);
+  module.impl(
+      "gdn_decode_value_conv_packed",
+      gdn_decode_value_conv_packed_meta);
+}

--- a/backend/triton_gaudi_runtime.cpp
+++ b/backend/triton_gaudi_runtime.cpp
@@ -718,6 +718,21 @@ std::shared_ptr<Artifact> parse_artifact(
             scalar_dtypes == std::vector<std::string>({"f32"}) &&
             artifact->bound_scalar_position < 0,
         "fused add+RMSNorm artifact has an incompatible tensor or scalar ABI");
+  } else if (kind == "silu_and_mul_dynamic_quant") {
+    artifact->kernel_kind = KernelKind::SiluAndMulDynamicQuant;
+    const auto& parameters = manifest.at("parameters");
+    artifact->logical_size = parameters.at("n_cols").get<std::uint32_t>();
+    require(
+        input_args.get<std::vector<std::size_t>>() ==
+                std::vector<std::size_t>({0}) &&
+            output_args == std::vector<std::size_t>({1, 2}) &&
+            scalar_order.empty() && artifact->bound_scalar_position < 0 &&
+            parameters.at("input_row_stride").get<std::uint32_t>() ==
+                2 * artifact->logical_size &&
+            parameters.at("fp8_max").get<double>() == 240.0 &&
+            std::abs(parameters.at("scale_epsilon").get<double>() - 1.0e-8) <=
+                1.0e-14,
+        "fused SiLU-and-mul dynamic quantization artifact has an incompatible ABI");
   } else if (kind == "dynamic_quant") {
     artifact->kernel_kind = KernelKind::DynamicQuant;
     const auto& parameters = manifest.at("parameters");
@@ -869,7 +884,8 @@ std::shared_ptr<Artifact> parse_artifact(
           artifact->kernel_kind != KernelKind::GdnDecodeConvPacked &&
           artifact->kernel_kind != KernelKind::GdnQkConvPacked &&
           artifact->kernel_kind != KernelKind::GdnDecodeValueConvPacked &&
-          artifact->kernel_kind != KernelKind::DynamicQuant) {
+          artifact->kernel_kind != KernelKind::DynamicQuant &&
+          artifact->kernel_kind != KernelKind::SiluAndMulDynamicQuant) {
         require(
             argument_dtype == tensor_dtype,
             "all generic TPC tensor arguments must use the manifest dtype");
@@ -886,6 +902,20 @@ std::shared_ptr<Artifact> parse_artifact(
             artifact->block_size <= 8192 &&
             (artifact->block_size & (artifact->block_size - 1)) == 0,
         "fused add+RMSNorm requires BF16 and a supported power-of-two block size");
+  } else if (
+      artifact->kernel_kind == KernelKind::SiluAndMulDynamicQuant) {
+    const std::vector<at::ScalarType> expected_dtypes{
+        at::kBFloat16, at::kFloat8_e4m3fn, at::kFloat};
+    require(
+        artifact->dtype == at::kFloat8_e4m3fn &&
+            artifact->tensor_dtypes == expected_dtypes &&
+            artifact->logical_size > 0 && artifact->logical_size <= 4096 &&
+            artifact->logical_size <= artifact->block_size &&
+            (artifact->logical_size == 1 ||
+             artifact->logical_size > artifact->block_size / 2) &&
+            artifact->block_size <= 8192 &&
+            (artifact->block_size & (artifact->block_size - 1)) == 0,
+        "fused SiLU-and-mul dynamic quantization requires BF16 to E4M3/f32 and a supported block size");
   } else if (artifact->kernel_kind == KernelKind::DynamicQuant) {
     const std::vector<at::ScalarType> expected_dtypes{
         at::kBFloat16, at::kFloat8_e4m3fn, at::kFloat};
@@ -1312,6 +1342,17 @@ void launch(
             static_cast<std::uint64_t>(tensors[3].numel()) == matrix_elements &&
             static_cast<std::uint64_t>(tensors[4].numel()) == matrix_elements,
         "fused add+RMSNorm tensor storage does not match grid rows and n_cols");
+  } else if (
+      artifact->kernel_kind == KernelKind::SiluAndMulDynamicQuant) {
+    const auto n_cols = artifact->logical_size;
+    const auto matrix_elements = grid[0] * static_cast<std::uint64_t>(n_cols);
+    require(
+        tensors.size() == 3 &&
+            static_cast<std::uint64_t>(tensors[0].numel()) ==
+                2 * matrix_elements &&
+            static_cast<std::uint64_t>(tensors[1].numel()) == matrix_elements &&
+            static_cast<std::uint64_t>(tensors[2].numel()) == grid[0],
+        "fused SiLU-and-mul dynamic quantization tensor storage does not match grid rows and n_cols");
   } else if (artifact->kernel_kind == KernelKind::DynamicQuant) {
     const auto n_cols = artifact->logical_size;
     const auto matrix_elements = grid[0] * static_cast<std::uint64_t>(n_cols);

--- a/backend/triton_gaudi_runtime.cpp
+++ b/backend/triton_gaudi_runtime.cpp
@@ -1,0 +1,1563 @@
+/**
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+#include "backend/triton_gaudi_runtime.h"
+
+#include <fcntl.h>
+#include <openssl/evp.h>
+#include <synapse_api.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <array>
+#include <algorithm>
+#include <atomic>
+#include <cerrno>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <nlohmann/json.hpp>
+#include <sstream>
+#include <stdexcept>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+
+#include "backend/habana_device/HPUDevice.h"
+#include "backend/habana_device/HPUStream.h"
+#include "backend/helpers/create_tensor.h"
+#include "backend/synapse_helpers/device.h"
+#include "backend/synapse_helpers/graph.h"
+#include "habana_lazy/hpu_lazy_tensors.h"
+#include "habana_lazy/lazy_executor.h"
+#include "include/habanalabs/triton_gaudi_launch.h"
+
+namespace habana::triton_gaudi {
+namespace {
+
+namespace fs = std::filesystem;
+
+struct CompiledRecipe {
+  std::shared_ptr<synapse_helpers::graph::recipe_handle> handle;
+  std::uint64_t workspace_size{0};
+  std::vector<std::string> tensor_names;
+  std::vector<std::uint64_t> tensor_ids;
+};
+
+struct Artifact {
+  std::string hash;
+  int device_id{0};
+  std::uint16_t input_count{0};
+  std::uint16_t output_count{0};
+  std::uint16_t scalar_count{0};
+  std::uint16_t index_space_rank{1};
+  std::uint32_t block_size{0};
+  std::uint32_t logical_size{0};
+  int bound_scalar_position{-1};
+  KernelKind kernel_kind{KernelKind::Elementwise};
+  at::ScalarType dtype{at::kFloat};
+  std::vector<at::ScalarType> tensor_dtypes;
+  std::vector<DTypeV2> tensor_dtype_codes;
+  std::vector<std::uint16_t> tensor_argument_indices;
+  std::vector<TensorRoleV2> tensor_roles;
+  std::vector<std::uint16_t> scalar_argument_indices;
+  std::vector<std::string> scalar_dtypes;
+  ArtifactManifestV1 perf_manifest{};
+  std::vector<std::size_t> mutable_input_positions;
+  std::uint32_t ref_count{1};
+  std::mutex recipe_mutex;
+  std::unordered_map<std::string, std::shared_ptr<CompiledRecipe>> recipes;
+};
+
+struct Registry {
+  std::mutex mutex;
+  std::atomic<std::uint64_t> next_handle{1};
+  std::unordered_map<std::uint64_t, std::shared_ptr<Artifact>> by_handle;
+  std::unordered_map<std::string, std::uint64_t> by_hash;
+};
+
+Registry& registry() {
+  // Synapse tears down the HPU device context before all shared-library and
+  // Python module destructors have run.  Process-lifetime recipe ownership
+  // avoids invoking recipe destructors against that partially destroyed
+  // context; normal unregister calls still release entries during execution.
+  static Registry* value = new Registry();
+  return *value;
+}
+
+void require(bool condition, const std::string& message) {
+  if (!condition) {
+    throw std::runtime_error("Triton Gaudi runtime: " + message);
+  }
+}
+
+bool is_lower_hex_hash(std::string_view hash) {
+  if (hash.size() != kArtifactHashChars) {
+    return false;
+  }
+  for (char value : hash) {
+    if (!((value >= '0' && value <= '9') ||
+          (value >= 'a' && value <= 'f'))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+DTypeV2 dtype_code(const std::string& dtype) {
+  if (dtype == "i1") {
+    return DTypeV2::Bool;
+  }
+  if (dtype == "bf16") {
+    return DTypeV2::BFloat16;
+  }
+  if (dtype == "f16") {
+    return DTypeV2::Float16;
+  }
+  if (dtype == "f32") {
+    return DTypeV2::Float32;
+  }
+  if (dtype == "f64") {
+    return DTypeV2::Float64;
+  }
+  if (dtype == "i8") {
+    return DTypeV2::Int8;
+  }
+  if (dtype == "i16") {
+    return DTypeV2::Int16;
+  }
+  if (dtype == "i32") {
+    return DTypeV2::Int32;
+  }
+  if (dtype == "i64") {
+    return DTypeV2::Int64;
+  }
+  if (dtype == "u8") {
+    return DTypeV2::UInt8;
+  }
+  if (dtype == "u16") {
+    return DTypeV2::UInt16;
+  }
+  if (dtype == "u32") {
+    return DTypeV2::UInt32;
+  }
+  if (dtype == "u64") {
+    return DTypeV2::UInt64;
+  }
+  if (dtype == "fp8e4nv") {
+    return DTypeV2::Float8E4NV;
+  }
+  if (dtype == "fp8e5") {
+    return DTypeV2::Float8E5;
+  }
+  throw std::runtime_error(
+      "Triton Gaudi runtime: unsupported launch dtype " + dtype);
+}
+
+TensorRoleV2 tensor_role(const std::string& role) {
+  if (role == "input") {
+    return TensorRoleV2::Input;
+  }
+  if (role == "output") {
+    return TensorRoleV2::Output;
+  }
+  if (role == "mutable_input") {
+    return TensorRoleV2::MutableInput;
+  }
+  throw std::runtime_error(
+      "Triton Gaudi runtime: unsupported tensor role " + role);
+}
+
+fs::path artifact_directory() {
+  const char* configured = std::getenv("TRITON_GAUDI_ARTIFACT_DIR");
+  require(
+      configured != nullptr && *configured != '\0',
+      "TRITON_GAUDI_ARTIFACT_DIR must name a private cache directory");
+  const fs::path directory(configured);
+  std::error_code error;
+  fs::create_directories(directory, error);
+  require(!error, "cannot create artifact directory: " + error.message());
+  require(
+      fs::is_directory(directory, error) && !fs::is_symlink(directory, error),
+      "artifact cache must be a real directory, not a symlink");
+  fs::permissions(
+      directory,
+      fs::perms::owner_all,
+      fs::perm_options::replace,
+      error);
+  require(!error, "cannot secure artifact directory: " + error.message());
+  return directory;
+}
+
+void write_all(int fd, const std::vector<std::uint8_t>& data) {
+  std::size_t written = 0;
+  while (written < data.size()) {
+    const ssize_t result =
+        ::write(fd, data.data() + written, data.size() - written);
+    if (result < 0 && errno == EINTR) {
+      continue;
+    }
+    require(result > 0, "failed to write artifact cache entry");
+    written += static_cast<std::size_t>(result);
+  }
+}
+
+void materialize_artifact_file(
+    const std::string& artifact_hash,
+    const std::string& suffix,
+    const std::vector<std::uint8_t>& data) {
+  const fs::path directory = artifact_directory();
+  const fs::path destination = directory / (artifact_hash + suffix);
+  std::error_code error;
+  const auto matches_expected = [&]() {
+    if (!fs::is_regular_file(destination, error) ||
+        fs::is_symlink(destination, error) ||
+        fs::file_size(destination, error) != data.size()) {
+      return false;
+    }
+    std::ifstream input(destination, std::ios::binary);
+    std::vector<std::uint8_t> existing{
+        std::istreambuf_iterator<char>(input),
+        std::istreambuf_iterator<char>()};
+    return existing == data;
+  };
+  if (fs::exists(destination, error)) {
+    require(matches_expected(), "an incompatible artifact already exists in the cache");
+    return;
+  }
+
+  const fs::path temporary = directory /
+      (artifact_hash + suffix + ".tmp." + std::to_string(::getpid()) + "." +
+       std::to_string(
+           registry().next_handle.load(std::memory_order_relaxed)));
+  const int fd = ::open(
+      temporary.c_str(),
+      O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW,
+      S_IRUSR | S_IWUSR);
+  require(fd >= 0, "cannot create temporary artifact cache entry");
+  bool fd_open = true;
+  try {
+    write_all(fd, data);
+    require(::fsync(fd) == 0, "cannot flush temporary artifact cache entry");
+    require(::close(fd) == 0, "cannot close temporary artifact cache entry");
+    fd_open = false;
+    if (::link(temporary.c_str(), destination.c_str()) != 0 &&
+        errno != EEXIST) {
+      throw std::runtime_error("Triton Gaudi runtime: cannot publish artifact");
+    }
+    fs::remove(temporary, error);
+    require(matches_expected(), "published artifact does not match the requested ELF");
+  } catch (...) {
+    if (fd_open) {
+      ::close(fd);
+    }
+    fs::remove(temporary, error);
+    throw;
+  }
+}
+
+void materialize_elf(
+    const std::string& artifact_hash,
+    const std::vector<std::uint8_t>& elf) {
+  require(
+      elf.size() >= 4 && elf[0] == 0x7f && elf[1] == 'E' &&
+          elf[2] == 'L' && elf[3] == 'F',
+      "artifact payload is not an ELF object");
+  require(elf.size() <= 64ULL * 1024ULL * 1024ULL, "TPC ELF is too large");
+  materialize_artifact_file(artifact_hash, ".elf", elf);
+}
+
+void materialize_manifest(
+    const std::string& artifact_hash,
+    const ArtifactManifestV1& manifest) {
+  const auto* begin = reinterpret_cast<const std::uint8_t*>(&manifest);
+  std::vector<std::uint8_t> bytes(begin, begin + sizeof(manifest));
+  materialize_artifact_file(artifact_hash, ".manifest", bytes);
+}
+
+#pragma pack(push, 1)
+struct ArtifactEnvelopeHeaderV2 {
+  char magic[4];
+  std::uint16_t major;
+  std::uint16_t minor;
+  std::uint32_t manifest_size;
+  std::uint64_t payload_size;
+};
+#pragma pack(pop)
+
+static_assert(sizeof(ArtifactEnvelopeHeaderV2) == 20);
+
+std::string sha256_hex(
+    const std::vector<std::pair<const void*, std::size_t>>& chunks) {
+  using DigestContext =
+      std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)>;
+  DigestContext context(EVP_MD_CTX_new(), &EVP_MD_CTX_free);
+  require(context != nullptr, "cannot allocate a SHA-256 context");
+  require(
+      EVP_DigestInit_ex(context.get(), EVP_sha256(), nullptr) == 1,
+      "cannot initialize SHA-256");
+  for (const auto& [data, size] : chunks) {
+    require(
+        EVP_DigestUpdate(context.get(), data, size) == 1,
+        "cannot update SHA-256");
+  }
+  std::array<unsigned char, EVP_MAX_MD_SIZE> digest{};
+  unsigned int digest_size = 0;
+  require(
+      EVP_DigestFinal_ex(context.get(), digest.data(), &digest_size) == 1 &&
+          digest_size == 32,
+      "cannot finalize SHA-256");
+  constexpr char alphabet[] = "0123456789abcdef";
+  std::string result(2 * digest_size, '0');
+  for (std::size_t index = 0; index < digest_size; ++index) {
+    result[2 * index] = alphabet[digest[index] >> 4];
+    result[2 * index + 1] = alphabet[digest[index] & 0x0f];
+  }
+  return result;
+}
+
+std::string sha256_hex(const std::vector<std::uint8_t>& data) {
+  return sha256_hex({{data.data(), data.size()}});
+}
+
+bool has_suffix(std::string_view value, std::string_view suffix) {
+  return value.size() >= suffix.size() &&
+      value.substr(value.size() - suffix.size()) == suffix;
+}
+
+void reject_artifact_paths(const nlohmann::json& value) {
+  if (value.is_object()) {
+    for (const auto& [key, child] : value.items()) {
+      require(
+          key != "path" && !has_suffix(key, "_path") &&
+              !has_suffix(key, "_directory"),
+          "Gaudi artifact manifests cannot contain filesystem paths");
+      reject_artifact_paths(child);
+    }
+  } else if (value.is_array()) {
+    for (const auto& child : value) {
+      reject_artifact_paths(child);
+    }
+  }
+}
+
+std::array<std::uint8_t, 2> little_u16(std::uint16_t value) {
+  return {
+      static_cast<std::uint8_t>(value & 0xff),
+      static_cast<std::uint8_t>((value >> 8) & 0xff)};
+}
+
+std::array<std::uint8_t, 8> little_u64(std::uint64_t value) {
+  std::array<std::uint8_t, 8> result{};
+  for (std::size_t index = 0; index < result.size(); ++index) {
+    result[index] = static_cast<std::uint8_t>((value >> (8 * index)) & 0xff);
+  }
+  return result;
+}
+
+struct DecodedArtifactV2 {
+  std::string hash;
+  std::vector<std::uint8_t> elf;
+  std::string legacy_manifest;
+};
+
+DecodedArtifactV2 decode_artifact_v2(
+    const std::vector<std::uint8_t>& envelope) {
+  constexpr std::size_t kMaxManifestBytes = 4ULL * 1024ULL * 1024ULL;
+  constexpr std::size_t kMaxPayloadBytes = 256ULL * 1024ULL * 1024ULL;
+  require(
+      envelope.size() >= sizeof(ArtifactEnvelopeHeaderV2),
+      "truncated GaudiKernelArtifactV2 header");
+  ArtifactEnvelopeHeaderV2 header{};
+  std::memcpy(&header, envelope.data(), sizeof(header));
+  require(
+      std::memcmp(header.magic, "GAK2", 4) == 0 && header.major == 2 &&
+          header.minor == 0,
+      "unsupported GaudiKernelArtifactV2 envelope");
+  require(
+      header.manifest_size <= kMaxManifestBytes &&
+          header.payload_size <= kMaxPayloadBytes,
+      "GaudiKernelArtifactV2 section exceeds the size limit");
+  const std::uint64_t expected = sizeof(header) +
+      static_cast<std::uint64_t>(header.manifest_size) +
+      header.payload_size;
+  require(
+      expected == envelope.size(),
+      "truncated or trailing data in GaudiKernelArtifactV2");
+
+  const auto* manifest_begin = envelope.data() + sizeof(header);
+  const std::string manifest_text(
+      reinterpret_cast<const char*>(manifest_begin), header.manifest_size);
+  auto manifest = nlohmann::json::parse(manifest_text);
+  require(
+      manifest.is_object() &&
+          manifest.value("abi", "") == "GaudiKernelArtifactV2" &&
+          manifest.value("abi_major", 0) == 2 &&
+          manifest.value("abi_minor", 1) == 0,
+      "invalid GaudiKernelArtifactV2 manifest ABI");
+  require(
+      manifest.value("target", "") == "gaudi2" &&
+          manifest.value("mode", "") == "strict",
+      "GaudiKernelArtifactV2 must be a strict Gaudi2 artifact");
+  reject_artifact_paths(manifest);
+  const std::string artifact_hash = manifest.value("artifact_hash", "");
+  require(
+      is_lower_hex_hash(artifact_hash),
+      "GaudiKernelArtifactV2 has an invalid artifact hash");
+
+  nlohmann::json descriptor;
+  std::string payload_name;
+  try {
+    require(
+        manifest.contains("payloads") && manifest.at("payloads").is_array(),
+        "GaudiKernelArtifactV2 payload descriptors must be an array");
+    const auto& payloads = manifest.at("payloads");
+    require(
+        payloads.size() == 1,
+        "Bridge ABI v2 currently accepts one TPC payload only");
+    descriptor = payloads.at(0);
+    require(
+        descriptor.is_object(),
+        "GaudiKernelArtifactV2 payload descriptors must be objects");
+    payload_name = descriptor.at("name").get<std::string>();
+    require(
+        !payload_name.empty() && payload_name.size() <= 0xffff &&
+            descriptor.value("kind", "") == "tpc_elf" &&
+            descriptor.value("offset", 1ULL) == 0 &&
+            descriptor.value("size", 0ULL) == header.payload_size,
+        "Bridge ABI v2 requires one contiguous TPC ELF payload");
+  } catch (const nlohmann::json::exception& error) {
+    throw std::runtime_error(
+        "Triton Gaudi runtime: invalid Artifact V2 payload descriptor JSON: " +
+        std::string(error.what()));
+  }
+  const auto* payload_begin = manifest_begin + header.manifest_size;
+  std::vector<std::uint8_t> elf(
+      payload_begin, payload_begin + header.payload_size);
+  const std::string payload_digest = descriptor.value("sha256", "");
+  require(
+      is_lower_hex_hash(payload_digest) && payload_digest == sha256_hex(elf),
+      "GaudiKernelArtifactV2 TPC payload digest mismatch");
+
+  try {
+    require(
+        manifest.contains("execution_plan") &&
+            manifest.at("execution_plan").is_object(),
+        "GaudiKernelArtifactV2 execution_plan must be an object");
+    const auto& plan = manifest.at("execution_plan");
+    require(
+        plan.contains("nodes") && plan.at("nodes").is_array(),
+        "GaudiKernelArtifactV2 execution-plan nodes must be an array");
+    const auto& nodes = plan.at("nodes");
+    require(
+        plan.value("version", 0) == 1 && nodes.size() == 1 &&
+            nodes.at(0).is_object() &&
+            nodes.at(0).value("engine", "") == "tpc" &&
+            nodes.at(0).value("payload", "") == payload_name,
+        "Bridge ABI v2 cannot drop multi-engine execution-plan nodes");
+  } catch (const nlohmann::json::exception& error) {
+    throw std::runtime_error(
+        "Triton Gaudi runtime: invalid Artifact V2 execution-plan JSON: " +
+        std::string(error.what()));
+  }
+
+  auto unhashed = manifest;
+  unhashed.erase("artifact_hash");
+  const std::string canonical_manifest = unhashed.dump(-1, ' ', true);
+  constexpr char prefix[] = "GaudiKernelArtifactV2";
+  const auto name_size = little_u16(
+      static_cast<std::uint16_t>(payload_name.size()));
+  const auto payload_size = little_u64(header.payload_size);
+  const std::string computed_hash = sha256_hex(
+      {{prefix, sizeof(prefix)},
+       {canonical_manifest.data(), canonical_manifest.size()},
+       {name_size.data(), name_size.size()},
+       {payload_size.data(), payload_size.size()},
+       {payload_name.data(), payload_name.size()},
+       {elf.data(), elf.size()}});
+  require(
+      computed_hash == artifact_hash,
+      "GaudiKernelArtifactV2 content digest mismatch");
+
+  manifest.erase("abi");
+  manifest.erase("abi_major");
+  manifest.erase("abi_minor");
+  manifest.erase("payloads");
+  manifest.erase("execution_plan");
+  manifest.erase("mode");
+  manifest["abi"] = "GaudiKernelArtifactV1";
+  manifest["abi_major"] = 1;
+  manifest["abi_minor"] = 0;
+  manifest["artifact_hash"] = artifact_hash;
+  manifest["elf_sha256"] = payload_digest;
+  return {artifact_hash, std::move(elf), manifest.dump()};
+}
+
+std::shared_ptr<Artifact> parse_artifact(
+    const std::string& artifact_hash,
+    const std::string& manifest_json,
+    int device_id) {
+  require(is_lower_hex_hash(artifact_hash), "artifact hash must be 64 lowercase hex characters");
+  const auto manifest = nlohmann::json::parse(manifest_json);
+  require(
+      manifest.value("abi", "") == "GaudiKernelArtifactV1" &&
+          manifest.value("abi_major", 0) == 1,
+      "unsupported kernel artifact ABI");
+  require(
+      manifest.value("target", "") == "gaudi2" &&
+          manifest.value("engine", "") == "tpc",
+      "only Gaudi2 TPC artifacts can be registered");
+  require(
+      manifest.value("artifact_hash", "") == artifact_hash,
+      "manifest and registration hashes differ");
+
+  const auto& arguments = manifest.at("arguments");
+  const auto& input_args = manifest.at("input_args");
+  const auto output_args = manifest.contains("output_args")
+      ? manifest.at("output_args").get<std::vector<std::size_t>>()
+      : std::vector<std::size_t>{
+            manifest.at("output_arg").get<std::size_t>()};
+  std::vector<std::size_t> tensor_order;
+  std::vector<std::size_t> scalar_order;
+  std::vector<std::string> scalar_dtypes;
+  std::size_t scalar_count = 0;
+  std::size_t argument_position = 0;
+  for (const auto& argument : arguments) {
+    const auto index = argument.at("index").get<std::size_t>();
+    require(
+        index == argument_position++,
+        "kernel argument indices must be contiguous and ordered");
+    const auto kind = argument.at("kind").get<std::string>();
+    const auto dtype = argument.at("dtype").get<std::string>();
+    if (kind == "tensor") {
+      require(
+          dtype == "f32" || dtype == "bf16" || dtype == "i32",
+          "launch ABI supports FP32, BF16, and I32 tensors only");
+      tensor_order.push_back(index);
+    } else {
+      require(
+          dtype == "i32" || dtype == "u32" || dtype == "f32",
+          "launch ABI supports i32/u32/f32 scalar parameters only");
+      scalar_order.push_back(index);
+      scalar_dtypes.push_back(dtype);
+      ++scalar_count;
+    }
+  }
+  std::vector<std::size_t> expected_order =
+      input_args.get<std::vector<std::size_t>>();
+  expected_order.insert(
+      expected_order.end(), output_args.begin(), output_args.end());
+  require(
+      tensor_order == expected_order,
+      "TPC tensor parameters must be ordered as inputs followed by output");
+  require(
+      scalar_count <= kMaxScalarParams,
+      "artifact exceeds the scalar parameter ABI limit");
+  require(
+      input_args.size() <= std::numeric_limits<std::uint16_t>::max() &&
+          output_args.size() <= std::numeric_limits<std::uint16_t>::max(),
+      "artifact tensor count exceeds the launch ABI limit");
+
+  const auto index_space = manifest.at("index_space");
+  auto artifact = std::make_shared<Artifact>();
+  artifact->hash = artifact_hash;
+  artifact->device_id = device_id;
+  artifact->input_count = static_cast<std::uint16_t>(input_args.size());
+  artifact->output_count = static_cast<std::uint16_t>(output_args.size());
+  artifact->scalar_count = static_cast<std::uint16_t>(scalar_count);
+  artifact->tensor_argument_indices.reserve(tensor_order.size());
+  for (const auto index : tensor_order) {
+    require(
+        index <= std::numeric_limits<std::uint16_t>::max(),
+        "tensor argument index exceeds the launch ABI limit");
+    artifact->tensor_argument_indices.push_back(
+        static_cast<std::uint16_t>(index));
+  }
+  artifact->scalar_argument_indices.reserve(scalar_order.size());
+  for (const auto index : scalar_order) {
+    require(
+        index <= std::numeric_limits<std::uint16_t>::max(),
+        "scalar argument index exceeds the launch ABI limit");
+    artifact->scalar_argument_indices.push_back(
+        static_cast<std::uint16_t>(index));
+  }
+  artifact->scalar_dtypes = scalar_dtypes;
+  try {
+    const auto& access_patterns = manifest.at("access_patterns");
+    require(
+        access_patterns.is_array(),
+        "artifact access_patterns must be an array");
+    std::unordered_map<std::size_t, const nlohmann::json*> accesses;
+    for (const auto& access : access_patterns) {
+      require(access.is_object(), "tensor access descriptors must be objects");
+      const auto index = access.at("arg").get<std::size_t>();
+      const auto inserted = accesses.emplace(index, &access);
+      require(inserted.second, "tensor access roles must be unique");
+    }
+    artifact->tensor_roles.reserve(tensor_order.size());
+    for (std::size_t position = 0; position < tensor_order.size(); ++position) {
+      const auto index = tensor_order[position];
+      const auto access = accesses.find(index);
+      require(
+          access != accesses.end(),
+          "every tensor argument requires an access role");
+      const auto role = tensor_role(
+          access->second->at("role").get<std::string>());
+      require(
+          position < artifact->input_count
+              ? role == TensorRoleV2::Input ||
+                  role == TensorRoleV2::MutableInput
+              : role == TensorRoleV2::Output,
+          "tensor access roles must agree with input/output argument lists");
+      artifact->tensor_roles.push_back(role);
+    }
+    artifact->index_space_rank =
+        static_cast<std::uint16_t>(index_space.value("rank", 1));
+    require(
+        artifact->index_space_rank > 0 &&
+            artifact->index_space_rank <= kMaxIndexSpaceRank,
+        "artifact index-space rank exceeds the perf-library ABI");
+
+    std::memcpy(
+        artifact->perf_manifest.magic,
+        kArtifactManifestMagic,
+        sizeof(artifact->perf_manifest.magic));
+    artifact->perf_manifest.abi_major = kArtifactManifestAbiMajor;
+    artifact->perf_manifest.abi_minor = kArtifactManifestAbiMinor;
+    artifact->perf_manifest.struct_size = sizeof(ArtifactManifestV1);
+    artifact->perf_manifest.index_space_rank = artifact->index_space_rank;
+    artifact->perf_manifest.input_count = artifact->input_count;
+    artifact->perf_manifest.output_count = artifact->output_count;
+    for (auto& tensor_access : artifact->perf_manifest.tensor_access) {
+      for (auto& mapping : tensor_access.mappings) {
+        mapping.all_required = 1;
+      }
+    }
+    const auto finite_float = [](const nlohmann::json& value) {
+      require(value.is_number(), "tensor access coefficients must be numeric");
+      const double number = value.get<double>();
+      require(
+          std::isfinite(number) &&
+              std::abs(number) <= std::numeric_limits<float>::max(),
+          "tensor access coefficient cannot be represented by the TPC ABI");
+      return static_cast<float>(number);
+    };
+    for (std::size_t position = 0; position < tensor_order.size(); ++position) {
+      auto& destination = artifact->perf_manifest.tensor_access[position];
+      const auto& mappings =
+          accesses.at(tensor_order[position])->at("mapping");
+      require(
+          mappings.is_array() && mappings.size() <= kMaxIndexSpaceRank,
+          "tensor access mappings exceed the perf-library ABI");
+      std::array<bool, kMaxIndexSpaceRank> mapped_dimensions{};
+      for (const auto& mapping : mappings) {
+        require(mapping.is_object(), "tensor access mappings must be objects");
+        const auto tensor_dim =
+            mapping.at("tensor_dim").get<std::size_t>();
+        const auto index_dim =
+            mapping.at("index_space_dim").get<std::size_t>();
+        require(
+            tensor_dim < kMaxIndexSpaceRank &&
+                !mapped_dimensions[tensor_dim],
+            "tensor access dimensions must be unique and in range");
+        require(
+            index_dim < artifact->index_space_rank,
+            "tensor access mapping references an invalid index-space dimension");
+        auto& output = destination.mappings[tensor_dim];
+        output.index_space_dim = static_cast<std::uint32_t>(index_dim);
+        output.a = finite_float(mapping.at("a"));
+        output.start_b = finite_float(mapping.at("start_b"));
+        output.end_b = finite_float(mapping.at("end_b"));
+        output.all_required = 0;
+        mapped_dimensions[tensor_dim] = true;
+      }
+    }
+  } catch (const nlohmann::json::exception& error) {
+    throw std::runtime_error(
+        "Triton Gaudi runtime: invalid access_patterns/index_space JSON: " +
+        std::string(error.what()));
+  }
+  artifact->block_size = index_space.at("block_size").get<std::uint32_t>();
+  artifact->logical_size = artifact->block_size;
+  if (!manifest.at("bound_arg").is_null()) {
+    const auto bound_arg = manifest.at("bound_arg").get<std::size_t>();
+    const auto bound = std::find(
+        scalar_order.begin(), scalar_order.end(), bound_arg);
+    require(
+        bound != scalar_order.end(),
+        "bound_arg must identify an i32/u32 scalar argument");
+    artifact->bound_scalar_position =
+        static_cast<int>(std::distance(scalar_order.begin(), bound));
+    require(
+        scalar_dtypes.at(
+            static_cast<std::size_t>(artifact->bound_scalar_position)) !=
+            "f32",
+        "bound_arg must identify an i32/u32 scalar argument");
+  }
+  const auto kind = manifest.value("kind", "elementwise");
+  if (kind == "fused_add_rms_norm") {
+    artifact->kernel_kind = KernelKind::FusedAddRmsNorm;
+    const auto& parameters = manifest.at("parameters");
+    artifact->logical_size = parameters.at("n_cols").get<std::uint32_t>();
+    require(
+        input_args.get<std::vector<std::size_t>>() ==
+                std::vector<std::size_t>({0, 1, 2}) &&
+            output_args == std::vector<std::size_t>({3, 4}) &&
+            scalar_order == std::vector<std::size_t>({5}) &&
+            scalar_dtypes == std::vector<std::string>({"f32"}) &&
+            artifact->bound_scalar_position < 0,
+        "fused add+RMSNorm artifact has an incompatible tensor or scalar ABI");
+  } else if (kind == "silu_and_mul") {
+    artifact->kernel_kind = KernelKind::SiluAndMul;
+    const auto& parameters = manifest.at("parameters");
+    artifact->logical_size = parameters.at("n_cols").get<std::uint32_t>();
+    require(
+        input_args.get<std::vector<std::size_t>>() ==
+                std::vector<std::size_t>({0}) &&
+            output_args == std::vector<std::size_t>({1}) &&
+            scalar_order.empty() && artifact->bound_scalar_position < 0 &&
+            parameters.at("input_row_stride").get<std::uint32_t>() ==
+                2 * artifact->logical_size &&
+            parameters.at("chunk_size").get<std::uint32_t>() ==
+                artifact->block_size &&
+            parameters.at("chunks_per_row").get<std::uint32_t>() ==
+                (artifact->logical_size + artifact->block_size - 1) /
+                    artifact->block_size,
+        "SiLU-and-mul artifact has an incompatible tensor or scalar ABI");
+  } else if (kind == "gdn_decode_packed") {
+    artifact->kernel_kind = KernelKind::GdnDecodePacked;
+    const auto& parameters = manifest.at("parameters");
+    artifact->logical_size = parameters.at("value_dim").get<std::uint32_t>();
+    artifact->mutable_input_positions = {
+        parameters.at("mutates_arg").get<std::size_t>()};
+    require(
+        input_args.get<std::vector<std::size_t>>() ==
+                std::vector<std::size_t>({0, 1, 2, 3, 4, 5, 6}) &&
+            output_args == std::vector<std::size_t>({7}) &&
+            scalar_order == std::vector<std::size_t>({8}) &&
+            scalar_dtypes == std::vector<std::string>({"i32"}) &&
+            artifact->bound_scalar_position < 0 &&
+            artifact->mutable_input_positions ==
+                std::vector<std::size_t>({0}) &&
+            parameters.at("key_heads").get<std::uint32_t>() == 16 &&
+            parameters.at("value_heads").get<std::uint32_t>() == 48 &&
+            parameters.at("key_dim").get<std::uint32_t>() == 128 &&
+            parameters.at("value_dim").get<std::uint32_t>() == 128 &&
+            parameters.at("packed_width").get<std::uint32_t>() == 10240 &&
+            parameters.at("value_tile").get<std::uint32_t>() ==
+                artifact->block_size &&
+            parameters.at("state_slots_arg").get<std::size_t>() == 8,
+        "packed GDN decode artifact has an incompatible tensor or scalar ABI");
+  } else if (kind == "gdn_decode_conv_packed") {
+    artifact->kernel_kind = KernelKind::GdnDecodeConvPacked;
+    const auto& parameters = manifest.at("parameters");
+    artifact->logical_size = parameters.at("value_dim").get<std::uint32_t>();
+    artifact->mutable_input_positions =
+        parameters.at("mutates_args").get<std::vector<std::size_t>>();
+    require(
+        input_args.get<std::vector<std::size_t>>() ==
+                std::vector<std::size_t>({0, 1, 2, 3, 4, 5, 6, 7, 8}) &&
+            output_args == std::vector<std::size_t>({9}) &&
+            scalar_order == std::vector<std::size_t>({10, 11}) &&
+            scalar_dtypes == std::vector<std::string>({"i32", "i32"}) &&
+            artifact->bound_scalar_position < 0 &&
+            artifact->mutable_input_positions ==
+                std::vector<std::size_t>({0, 1}) &&
+            parameters.at("key_heads").get<std::uint32_t>() == 16 &&
+            parameters.at("value_heads").get<std::uint32_t>() == 48 &&
+            parameters.at("key_dim").get<std::uint32_t>() == 128 &&
+            parameters.at("value_dim").get<std::uint32_t>() == 128 &&
+            parameters.at("packed_width").get<std::uint32_t>() == 10240 &&
+            parameters.at("conv_width").get<std::uint32_t>() == 4 &&
+            parameters.at("conv_slots_arg").get<std::size_t>() == 10 &&
+            parameters.at("state_slots_arg").get<std::size_t>() == 11,
+        "fused conv+GDN artifact has an incompatible tensor or scalar ABI");
+  } else if (kind == "gdn_qk_conv_packed") {
+    artifact->kernel_kind = KernelKind::GdnQkConvPacked;
+    const auto& parameters = manifest.at("parameters");
+    artifact->logical_size = parameters.at("channels").get<std::uint32_t>();
+    artifact->mutable_input_positions =
+        parameters.at("mutates_args").get<std::vector<std::size_t>>();
+    require(
+        input_args.get<std::vector<std::size_t>>() ==
+                std::vector<std::size_t>({0, 1, 2, 3}) &&
+            output_args == std::vector<std::size_t>({4}) &&
+            scalar_order == std::vector<std::size_t>({5}) &&
+            scalar_dtypes == std::vector<std::string>({"i32"}) &&
+            artifact->bound_scalar_position < 0 &&
+            artifact->mutable_input_positions ==
+                std::vector<std::size_t>({0}) &&
+            artifact->logical_size == 4096 &&
+            parameters.at("packed_width").get<std::uint32_t>() == 10240 &&
+            parameters.at("conv_width").get<std::uint32_t>() == 4 &&
+            parameters.at("conv_slots_arg").get<std::size_t>() == 5,
+        "packed Q/K convolution artifact has an incompatible ABI");
+  } else if (kind == "gdn_decode_value_conv_packed") {
+    artifact->kernel_kind = KernelKind::GdnDecodeValueConvPacked;
+    const auto& parameters = manifest.at("parameters");
+    artifact->logical_size = parameters.at("value_dim").get<std::uint32_t>();
+    artifact->mutable_input_positions =
+        parameters.at("mutates_args").get<std::vector<std::size_t>>();
+    require(
+        input_args.get<std::vector<std::size_t>>() ==
+                std::vector<std::size_t>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}) &&
+            output_args == std::vector<std::size_t>({10}) &&
+            scalar_order == std::vector<std::size_t>({11, 12}) &&
+            scalar_dtypes == std::vector<std::string>({"i32", "i32"}) &&
+            artifact->bound_scalar_position < 0 &&
+            artifact->mutable_input_positions ==
+                std::vector<std::size_t>({0, 1}) &&
+            parameters.at("key_heads").get<std::uint32_t>() == 16 &&
+            parameters.at("value_heads").get<std::uint32_t>() == 48 &&
+            parameters.at("key_dim").get<std::uint32_t>() == 128 &&
+            parameters.at("value_dim").get<std::uint32_t>() == 128 &&
+            parameters.at("packed_width").get<std::uint32_t>() == 10240 &&
+            parameters.at("qk_width").get<std::uint32_t>() == 4096 &&
+            parameters.at("conv_width").get<std::uint32_t>() == 4 &&
+            parameters.at("value_tile").get<std::uint32_t>() ==
+                artifact->block_size &&
+            parameters.at("conv_slots_arg").get<std::size_t>() == 11 &&
+            parameters.at("state_slots_arg").get<std::size_t>() == 12,
+        "fused value-conv + GDN artifact has an incompatible ABI");
+  } else {
+    require(kind == "elementwise", "manifest has an unsupported TPC kernel kind");
+  }
+  const auto tensor_dtype = manifest.value("tensor_dtype", "");
+  artifact->dtype = tensor_dtype == "bf16" ? at::kBFloat16 : at::kFloat;
+  require(
+      tensor_dtype == "f32" || tensor_dtype == "bf16",
+      "manifest has an unsupported tensor dtype");
+  artifact->tensor_dtypes.reserve(tensor_order.size());
+  artifact->tensor_dtype_codes.reserve(tensor_order.size());
+  for (const auto& argument : arguments) {
+    if (argument.at("kind").get<std::string>() == "tensor") {
+      const auto argument_dtype = argument.at("dtype").get<std::string>();
+      artifact->tensor_dtype_codes.push_back(dtype_code(argument_dtype));
+      artifact->tensor_dtypes.push_back(
+          argument_dtype == "bf16"
+              ? at::kBFloat16
+              : argument_dtype == "i32" ? at::kInt : at::kFloat);
+      if (artifact->kernel_kind != KernelKind::GdnDecodePacked &&
+          artifact->kernel_kind != KernelKind::GdnDecodeConvPacked &&
+          artifact->kernel_kind != KernelKind::GdnQkConvPacked &&
+          artifact->kernel_kind != KernelKind::GdnDecodeValueConvPacked) {
+        require(
+            argument_dtype == tensor_dtype,
+            "all generic TPC tensor arguments must use the manifest dtype");
+      }
+    }
+  }
+  if (artifact->kernel_kind == KernelKind::FusedAddRmsNorm) {
+    require(
+        artifact->dtype == at::kBFloat16 &&
+            artifact->logical_size > 0 &&
+            artifact->logical_size <= artifact->block_size &&
+            (artifact->logical_size == 1 ||
+             artifact->logical_size > artifact->block_size / 2) &&
+            artifact->block_size <= 8192 &&
+            (artifact->block_size & (artifact->block_size - 1)) == 0,
+        "fused add+RMSNorm requires BF16 and a supported power-of-two block size");
+  } else if (artifact->kernel_kind == KernelKind::SiluAndMul) {
+    require(
+        artifact->dtype == at::kBFloat16 &&
+            artifact->logical_size > 0 &&
+            artifact->logical_size <= 65536 &&
+            artifact->block_size >= 128 &&
+            artifact->block_size <= 1024 &&
+            (artifact->block_size & (artifact->block_size - 1)) == 0,
+        "SiLU-and-mul requires BF16 and a supported power-of-two block size");
+  } else if (artifact->kernel_kind == KernelKind::GdnDecodePacked) {
+    const std::vector<at::ScalarType> expected_dtypes{
+        at::kFloat,
+        at::kBFloat16,
+        at::kBFloat16,
+        at::kBFloat16,
+        at::kFloat,
+        at::kFloat,
+        at::kInt,
+        at::kBFloat16};
+    require(
+        artifact->dtype == at::kBFloat16 &&
+            artifact->tensor_dtypes == expected_dtypes &&
+            artifact->logical_size == 128 &&
+            (artifact->block_size == 16 || artifact->block_size == 32 ||
+             artifact->block_size == 64 || artifact->block_size == 128),
+        "packed GDN decode requires the canonical mixed dtypes and value tile");
+  } else if (artifact->kernel_kind == KernelKind::GdnDecodeConvPacked) {
+    const std::vector<at::ScalarType> expected_dtypes{
+        at::kBFloat16,
+        at::kFloat,
+        at::kBFloat16,
+        at::kBFloat16,
+        at::kBFloat16,
+        at::kFloat,
+        at::kFloat,
+        at::kInt,
+        at::kBFloat16,
+        at::kBFloat16};
+    require(
+        artifact->dtype == at::kBFloat16 &&
+            artifact->tensor_dtypes == expected_dtypes &&
+            artifact->logical_size == 128 && artifact->block_size == 128,
+        "fused conv+GDN requires the canonical mixed dtypes and ownership tile");
+  } else if (artifact->kernel_kind == KernelKind::GdnQkConvPacked) {
+    const std::vector<at::ScalarType> expected_dtypes{
+        at::kBFloat16,
+        at::kBFloat16,
+        at::kInt,
+        at::kBFloat16,
+        at::kBFloat16};
+    require(
+        artifact->dtype == at::kBFloat16 &&
+            artifact->tensor_dtypes == expected_dtypes &&
+            artifact->logical_size == 4096 &&
+            (artifact->block_size == 128 || artifact->block_size == 256 ||
+             artifact->block_size == 512),
+        "packed Q/K convolution requires canonical dtypes and channel tile");
+  } else if (
+      artifact->kernel_kind == KernelKind::GdnDecodeValueConvPacked) {
+    const std::vector<at::ScalarType> expected_dtypes{
+        at::kBFloat16,
+        at::kFloat,
+        at::kBFloat16,
+        at::kBFloat16,
+        at::kBFloat16,
+        at::kBFloat16,
+        at::kFloat,
+        at::kFloat,
+        at::kInt,
+        at::kBFloat16,
+        at::kBFloat16};
+    require(
+        artifact->dtype == at::kBFloat16 &&
+            artifact->tensor_dtypes == expected_dtypes &&
+            artifact->logical_size == 128 &&
+            (artifact->block_size == 16 || artifact->block_size == 32 ||
+             artifact->block_size == 64 || artifact->block_size == 128),
+        "fused value-conv + GDN requires canonical dtypes and value tile");
+  }
+  require(
+      artifact->input_count > 0 && artifact->output_count > 0 &&
+          artifact->block_size > 0 &&
+          (artifact->kernel_kind == KernelKind::SiluAndMul
+               ? artifact->index_space_rank == 2
+               : artifact->kernel_kind == KernelKind::GdnDecodePacked
+               ? artifact->index_space_rank == 3
+               : artifact->kernel_kind == KernelKind::GdnDecodeConvPacked
+               ? artifact->index_space_rank == 2
+               : artifact->kernel_kind == KernelKind::GdnQkConvPacked
+               ? artifact->index_space_rank == 2
+               : artifact->kernel_kind == KernelKind::GdnDecodeValueConvPacked
+               ? artifact->index_space_rank == 3
+               : artifact->index_space_rank == 1),
+      "invalid initial TPC index-space metadata");
+  return artifact;
+}
+
+std::shared_ptr<Artifact> lookup(std::uint64_t handle) {
+  auto& state = registry();
+  std::lock_guard<std::mutex> guard(state.mutex);
+  const auto iterator = state.by_handle.find(handle);
+  require(iterator != state.by_handle.end(), "unknown or released artifact handle");
+  return iterator->second;
+}
+
+void validate_tensor(
+    const at::Tensor& tensor,
+    at::ScalarType dtype,
+    int device_id) {
+  require(tensor.defined(), "kernel tensor argument is undefined");
+  require(tensor.device().type() == at::kHPU, "kernel tensors must reside on HPU");
+  require(
+      tensor.device().index() == device_id,
+      "kernel tensors must reside on the artifact's HPU device");
+  require(
+      tensor.scalar_type() == dtype,
+      "kernel tensor dtype does not match the compiled artifact");
+  require(tensor.is_contiguous(), "initial launch ABI requires contiguous tensors");
+  require(tensor.numel() > 0, "zero-sized tensors are not supported by the initial launch ABI");
+  require(
+      tensor.numel() <= std::numeric_limits<unsigned>::max(),
+      "tensor is too large for the Synapse tensor descriptor");
+}
+
+LaunchParamsV1 make_launch_params(
+    const Artifact& artifact,
+    const std::vector<std::uint64_t>& grid,
+    const std::vector<std::uint32_t>& scalar_params) {
+  LaunchParamsV1 params{};
+  params.input_count = artifact.input_count;
+  params.output_count = artifact.output_count;
+  params.scalar_count = artifact.scalar_count;
+  params.index_space_rank = artifact.index_space_rank;
+  params.block_size = artifact.block_size;
+  params.logical_size = artifact.logical_size;
+  params.tensor_dtype = artifact.dtype == at::kBFloat16
+      ? 1U << 8 // tpc_lib_api::DATA_BF16
+      : 1U << 12; // tpc_lib_api::DATA_F32
+  params.kernel_kind = artifact.kernel_kind;
+  std::copy_n(
+      grid.begin(), artifact.index_space_rank, params.grid.begin());
+  std::copy(
+      scalar_params.begin(), scalar_params.end(), params.scalar_params.begin());
+  std::copy(
+      artifact.hash.begin(), artifact.hash.end(), params.artifact_hash.begin());
+  return params;
+}
+
+std::string recipe_key(
+    const std::vector<std::uint64_t>& grid,
+    const std::vector<at::Tensor>& tensors,
+    const std::vector<std::uint32_t>& scalar_params) {
+  std::ostringstream key;
+  key << "g";
+  for (const auto value : grid) {
+    key << ':' << value;
+  }
+  key << "|n";
+  for (const auto& tensor : tensors) {
+    key << ':' << tensor.scalar_type() << '[';
+    for (const auto size : tensor.sizes()) {
+      key << size << ',';
+    }
+    key << ']';
+  }
+  key << "|s";
+  for (const auto value : scalar_params) {
+    key << ':' << value;
+  }
+  return key.str();
+}
+
+std::shared_ptr<CompiledRecipe> compile_recipe(
+    const std::shared_ptr<Artifact>& artifact,
+    const std::vector<std::uint64_t>& grid,
+    const std::vector<at::Tensor>& tensors,
+    const std::vector<std::uint32_t>& scalar_params) {
+  auto& device = HPUDeviceContext::get_device();
+  auto graph = synapse_helpers::graph::create(
+      device, "triton_gaudi_" + artifact->hash.substr(0, 16));
+
+  std::vector<synapse_helpers::tensor> tensor_owners;
+  std::vector<synTensor> inputs;
+  std::vector<synTensor> outputs;
+  tensor_owners.reserve(tensors.size());
+  inputs.reserve(artifact->input_count);
+  outputs.reserve(artifact->output_count);
+
+  auto compiled = std::make_shared<CompiledRecipe>();
+  compiled->tensor_names.reserve(tensors.size());
+  for (std::size_t index = 0; index < tensors.size(); ++index) {
+    std::vector<std::int64_t> shape;
+    std::vector<std::int64_t> stride;
+    if (artifact->kernel_kind == KernelKind::SiluAndMul ||
+        artifact->kernel_kind == KernelKind::GdnDecodePacked ||
+        artifact->kernel_kind == KernelKind::GdnDecodeConvPacked ||
+        artifact->kernel_kind == KernelKind::GdnQkConvPacked ||
+        artifact->kernel_kind == KernelKind::GdnDecodeValueConvPacked) {
+      shape = tensors[index].sizes().vec();
+      stride = tensors[index].strides().vec();
+    } else {
+      shape = {tensors[index].numel()};
+      stride = {1};
+    }
+    auto syn_tensor = habana_helpers::create_tensor(
+        c10::IntArrayRef(shape),
+        c10::IntArrayRef(stride),
+        graph,
+        true,
+        false,
+        static_cast<int>(device.id()),
+        artifact->tensor_dtypes.at(index),
+        "triton_arg_" + std::to_string(index));
+    compiled->tensor_names.push_back(syn_tensor.name());
+    if (index < artifact->input_count) {
+      inputs.push_back(syn_tensor.get());
+    } else {
+      outputs.push_back(syn_tensor.get());
+    }
+    tensor_owners.push_back(std::move(syn_tensor));
+  }
+
+  auto params = make_launch_params(*artifact, grid, scalar_params);
+  graph.add_node(
+      std::move(inputs),
+      std::move(outputs),
+      &params,
+      sizeof(params),
+      kKernelGuid,
+      nullptr,
+      nullptr,
+      nullptr,
+      false);
+  compiled->handle = graph.compile();
+  require(compiled->handle != nullptr, "Synapse produced an empty TPC recipe");
+  compiled->workspace_size =
+      synapse_helpers::graph::query_workspace_size(*compiled->handle);
+
+  std::vector<const char*> names;
+  names.reserve(compiled->tensor_names.size());
+  for (const auto& name : compiled->tensor_names) {
+    names.push_back(name.c_str());
+  }
+  compiled->tensor_ids.resize(names.size());
+  const synStatus status = synTensorRetrieveIds(
+      compiled->handle->syn_recipe_handle_,
+      names.data(),
+      compiled->tensor_ids.data(),
+      static_cast<std::uint32_t>(names.size()));
+  require(
+      status == synSuccess,
+      "synTensorRetrieveIds failed with status " + std::to_string(status));
+  return compiled;
+}
+
+std::shared_ptr<CompiledRecipe> get_or_compile_recipe(
+    const std::shared_ptr<Artifact>& artifact,
+    const std::vector<std::uint64_t>& grid,
+    const std::vector<at::Tensor>& tensors,
+    const std::vector<std::uint32_t>& scalar_params) {
+  const auto key = recipe_key(grid, tensors, scalar_params);
+  std::lock_guard<std::mutex> guard(artifact->recipe_mutex);
+  if (const auto iterator = artifact->recipes.find(key);
+      iterator != artifact->recipes.end()) {
+    return iterator->second;
+  }
+  auto compiled = compile_recipe(artifact, grid, tensors, scalar_params);
+  artifact->recipes.emplace(key, compiled);
+  return compiled;
+}
+
+struct LaunchResources {
+  std::vector<at::Tensor> tensors;
+  std::shared_ptr<Artifact> artifact;
+  std::shared_ptr<CompiledRecipe> recipe;
+  std::unique_ptr<synapse_helpers::device_ptr_lock> address_lock;
+};
+
+} // namespace
+
+std::uint64_t register_artifact(
+    const std::string& artifact_hash,
+    const std::vector<std::uint8_t>& elf,
+    const std::string& manifest_json,
+    int device_id) {
+  require(
+      device_id >= 0 &&
+          device_id ==
+              static_cast<int>(HPUDeviceContext::get_device().id()),
+      "artifact device does not match the active HPU");
+  auto artifact = parse_artifact(artifact_hash, manifest_json, device_id);
+  materialize_elf(artifact_hash, elf);
+  materialize_manifest(artifact_hash, artifact->perf_manifest);
+
+  auto& state = registry();
+  std::lock_guard<std::mutex> guard(state.mutex);
+  const std::string artifact_key =
+      artifact_hash + ":" + std::to_string(device_id);
+  if (const auto existing = state.by_hash.find(artifact_key);
+      existing != state.by_hash.end()) {
+    auto registered = state.by_handle.at(existing->second);
+    ++registered->ref_count;
+    return existing->second;
+  }
+  const std::uint64_t handle =
+      state.next_handle.fetch_add(1, std::memory_order_relaxed);
+  state.by_handle.emplace(handle, std::move(artifact));
+  state.by_hash.emplace(artifact_key, handle);
+  return handle;
+}
+
+std::uint64_t register_artifact_v2(
+    const std::vector<std::uint8_t>& envelope,
+    int device_id) {
+  DecodedArtifactV2 decoded;
+  try {
+    decoded = decode_artifact_v2(envelope);
+  } catch (const nlohmann::json::exception& error) {
+    throw std::runtime_error(
+        "Triton Gaudi runtime: invalid Artifact V2 envelope JSON: " +
+        std::string(error.what()));
+  }
+  try {
+    return register_artifact(
+        decoded.hash,
+        decoded.elf,
+        decoded.legacy_manifest,
+        device_id);
+  } catch (const nlohmann::json::exception& error) {
+    throw std::runtime_error(
+        "Triton Gaudi runtime: invalid projected launch manifest JSON: " +
+        std::string(error.what()));
+  }
+}
+
+void unregister_artifact(std::uint64_t handle) {
+  auto& state = registry();
+  std::lock_guard<std::mutex> guard(state.mutex);
+  const auto iterator = state.by_handle.find(handle);
+  if (iterator == state.by_handle.end()) {
+    return;
+  }
+  if (--iterator->second->ref_count != 0) {
+    return;
+  }
+  state.by_hash.erase(
+      iterator->second->hash + ":" +
+      std::to_string(iterator->second->device_id));
+  state.by_handle.erase(iterator);
+}
+
+void launch(
+    std::uint64_t handle,
+    const std::vector<std::uint64_t>& grid,
+    std::uint64_t hpu_stream,
+    const std::vector<at::Tensor>& tensors,
+    const std::vector<std::uint32_t>& scalar_params) {
+  const auto artifact = lookup(handle);
+  require(grid.size() == 3, "launch grid must have three dimensions");
+  if (artifact->kernel_kind == KernelKind::SiluAndMul) {
+    require(
+        grid[0] > 0 && grid[1] > 0 && grid[2] == 1,
+        "SiLU-and-mul requires a non-empty two-dimensional grid");
+  } else if (artifact->kernel_kind == KernelKind::GdnDecodePacked) {
+    require(
+        grid[0] > 0 && grid[1] == 48 && grid[2] > 0,
+        "packed GDN decode requires a non-empty three-dimensional grid");
+  } else if (artifact->kernel_kind == KernelKind::GdnDecodeConvPacked) {
+    require(
+        grid[0] == 16 && grid[1] > 0 && grid[2] == 1,
+        "fused conv+GDN requires key-head by batch index space");
+  } else if (artifact->kernel_kind == KernelKind::GdnQkConvPacked) {
+    require(
+        grid[0] == 4096 / artifact->block_size && grid[1] > 0 &&
+            grid[2] == 1,
+        "packed Q/K convolution requires channel-block by batch index space");
+  } else if (
+      artifact->kernel_kind == KernelKind::GdnDecodeValueConvPacked) {
+    require(
+        grid[0] > 0 && grid[1] == 48 && grid[2] > 0,
+        "fused value-conv + GDN requires tile by head by batch index space");
+  } else {
+    require(
+        grid[0] > 0 && grid[1] == 1 && grid[2] == 1,
+        "initial TPC launch supports a non-empty one-dimensional grid only");
+  }
+  require(
+      tensors.size() == artifact->input_count + artifact->output_count,
+      "tensor argument count does not match the artifact");
+  require(
+      scalar_params.size() == artifact->scalar_count,
+      "scalar argument count does not match the artifact");
+  require(
+      grid[0] <= std::numeric_limits<std::uint32_t>::max() &&
+          grid[1] <= std::numeric_limits<std::uint32_t>::max() &&
+          grid[2] <= std::numeric_limits<std::uint32_t>::max(),
+      "TPC index-space geometry exceeds the Gaudi2 ABI");
+  require(
+      artifact->device_id ==
+          static_cast<int>(HPUDeviceContext::get_device().id()),
+      "artifact device does not match the active HPU");
+  if (artifact->kernel_kind == KernelKind::FusedAddRmsNorm) {
+    const auto n_cols = artifact->logical_size;
+    const auto matrix_elements = grid[0] * static_cast<std::uint64_t>(n_cols);
+    require(
+        tensors.size() == 5 &&
+            static_cast<std::uint64_t>(tensors[0].numel()) == matrix_elements &&
+            static_cast<std::uint64_t>(tensors[1].numel()) == matrix_elements &&
+            static_cast<std::uint64_t>(tensors[2].numel()) == n_cols &&
+            static_cast<std::uint64_t>(tensors[3].numel()) == matrix_elements &&
+            static_cast<std::uint64_t>(tensors[4].numel()) == matrix_elements,
+        "fused add+RMSNorm tensor storage does not match grid rows and n_cols");
+  } else if (artifact->kernel_kind == KernelKind::SiluAndMul) {
+    const auto n_cols = artifact->logical_size;
+    const auto rows = grid[1];
+    const auto rows_i64 = static_cast<std::int64_t>(rows);
+    const auto matrix_elements = rows * static_cast<std::uint64_t>(n_cols);
+    require(
+        grid[0] == (n_cols + artifact->block_size - 1) / artifact->block_size &&
+            tensors.size() == 2 && tensors[0].dim() == 2 &&
+            tensors[1].dim() == 2 && tensors[0].size(0) == rows_i64 &&
+            tensors[0].size(1) == 2 * n_cols &&
+            tensors[1].size(0) == rows_i64 && tensors[1].size(1) == n_cols &&
+            static_cast<std::uint64_t>(tensors[0].numel()) == 2 * matrix_elements &&
+            static_cast<std::uint64_t>(tensors[1].numel()) == matrix_elements,
+        "SiLU-and-mul tensor storage does not match grid rows and n_cols");
+  } else if (artifact->kernel_kind == KernelKind::GdnDecodePacked) {
+    const auto batch = static_cast<std::int64_t>(grid[2]);
+    const auto state_slots = static_cast<std::int64_t>(scalar_params.at(0));
+    require(
+        grid[0] == 128 / artifact->block_size &&
+            tensors.size() == 8 && state_slots > 0 &&
+            tensors[0].sizes() ==
+                at::IntArrayRef({state_slots, 48, 128, 128}) &&
+            tensors[1].sizes() == at::IntArrayRef({batch, 10240}) &&
+            tensors[2].sizes() == at::IntArrayRef({batch, 48}) &&
+            tensors[3].sizes() == at::IntArrayRef({batch, 48}) &&
+            tensors[4].sizes() == at::IntArrayRef({48}) &&
+            tensors[5].sizes() == at::IntArrayRef({48}) &&
+            tensors[6].sizes() == at::IntArrayRef({batch}) &&
+            tensors[7].sizes() == at::IntArrayRef({batch, 48, 128}),
+        "packed GDN decode tensor storage does not match the Qwen3.5 specialization");
+  } else if (artifact->kernel_kind == KernelKind::GdnDecodeConvPacked) {
+    const auto batch = static_cast<std::int64_t>(grid[1]);
+    const auto conv_slots = static_cast<std::int64_t>(scalar_params.at(0));
+    const auto state_slots = static_cast<std::int64_t>(scalar_params.at(1));
+    require(
+        tensors.size() == 10 && conv_slots > 0 && state_slots > 0 &&
+            tensors[0].sizes() ==
+                at::IntArrayRef({conv_slots, 3, 10240}) &&
+            tensors[1].sizes() ==
+                at::IntArrayRef({state_slots, 48, 128, 128}) &&
+            tensors[2].sizes() == at::IntArrayRef({batch, 10240}) &&
+            tensors[3].sizes() == at::IntArrayRef({batch, 48}) &&
+            tensors[4].sizes() == at::IntArrayRef({batch, 48}) &&
+            tensors[5].sizes() == at::IntArrayRef({48}) &&
+            tensors[6].sizes() == at::IntArrayRef({48}) &&
+            tensors[7].sizes() == at::IntArrayRef({batch}) &&
+            tensors[8].sizes() == at::IntArrayRef({4, 10240}) &&
+            tensors[9].sizes() == at::IntArrayRef({batch, 48, 128}),
+        "fused conv+GDN tensor storage does not match the Qwen3.5 specialization");
+  } else if (artifact->kernel_kind == KernelKind::GdnQkConvPacked) {
+    const auto batch = static_cast<std::int64_t>(grid[1]);
+    const auto conv_slots = static_cast<std::int64_t>(scalar_params.at(0));
+    require(
+        tensors.size() == 5 && conv_slots > 0 &&
+            tensors[0].sizes() ==
+                at::IntArrayRef({conv_slots, 3, 10240}) &&
+            tensors[1].sizes() == at::IntArrayRef({batch, 10240}) &&
+            tensors[2].sizes() == at::IntArrayRef({batch}) &&
+            tensors[3].sizes() == at::IntArrayRef({4, 10240}) &&
+            tensors[4].sizes() == at::IntArrayRef({batch, 4096}),
+        "packed Q/K convolution tensor storage does not match Qwen3.5");
+  } else if (
+      artifact->kernel_kind == KernelKind::GdnDecodeValueConvPacked) {
+    const auto batch = static_cast<std::int64_t>(grid[2]);
+    const auto conv_slots = static_cast<std::int64_t>(scalar_params.at(0));
+    const auto state_slots = static_cast<std::int64_t>(scalar_params.at(1));
+    require(
+        grid[0] == 128 / artifact->block_size && tensors.size() == 11 &&
+            conv_slots > 0 && state_slots > 0 &&
+            tensors[0].sizes() ==
+                at::IntArrayRef({conv_slots, 3, 10240}) &&
+            tensors[1].sizes() ==
+                at::IntArrayRef({state_slots, 48, 128, 128}) &&
+            tensors[2].sizes() == at::IntArrayRef({batch, 4096}) &&
+            tensors[3].sizes() == at::IntArrayRef({batch, 10240}) &&
+            tensors[4].sizes() == at::IntArrayRef({batch, 48}) &&
+            tensors[5].sizes() == at::IntArrayRef({batch, 48}) &&
+            tensors[6].sizes() == at::IntArrayRef({48}) &&
+            tensors[7].sizes() == at::IntArrayRef({48}) &&
+            tensors[8].sizes() == at::IntArrayRef({batch}) &&
+            tensors[9].sizes() == at::IntArrayRef({4, 10240}) &&
+            tensors[10].sizes() == at::IntArrayRef({batch, 48, 128}),
+        "fused value-conv + GDN tensor storage does not match Qwen3.5");
+  } else if (artifact->bound_scalar_position >= 0) {
+    const auto logical_elements = scalar_params.at(
+        static_cast<std::size_t>(artifact->bound_scalar_position));
+    require(logical_elements > 0, "masked TPC launch requires a positive runtime bound");
+    const auto expected_grid =
+        (static_cast<std::uint64_t>(logical_elements) + artifact->block_size - 1) /
+        artifact->block_size;
+    require(
+        grid[0] == expected_grid,
+        "launch grid does not cover the masked runtime bound exactly");
+    for (const auto& tensor : tensors) {
+      require(
+          logical_elements <= static_cast<std::uint64_t>(tensor.numel()),
+          "runtime bound exceeds a kernel tensor's storage");
+    }
+  } else {
+    const auto covered_elements = grid[0] * artifact->block_size;
+    for (const auto& tensor : tensors) {
+      require(
+          covered_elements <= static_cast<std::uint64_t>(tensor.numel()),
+          "unmasked launch grid exceeds a kernel tensor's storage");
+    }
+  }
+  for (std::size_t index = 0; index < tensors.size(); ++index) {
+    validate_tensor(
+        tensors[index], artifact->tensor_dtypes.at(index), artifact->device_id);
+  }
+
+  auto* execution_context = habana_lazy::get_device_lazy_execution_context();
+  require(
+      execution_context->getCaptureGraph() == nullptr,
+      "direct TPC launch is not HPUGraph-capturable; use GaudiCompiledGraphOp");
+  // Materialize pending lazy producers before submitting the external recipe.
+  // In eager mode producer events already describe the dependency and calling
+  // StepMarker would add avoidable host overhead.
+  if (GET_ENV_FLAG_NEW(PT_HPU_LAZY_MODE) == 1) {
+    habana_lazy::HbLazyTensor::StepMarker({});
+  }
+
+  const auto recipe =
+      get_or_compile_recipe(artifact, grid, tensors, scalar_params);
+  auto resources = std::make_shared<LaunchResources>();
+  resources->tensors = tensors;
+  resources->artifact = artifact;
+  resources->recipe = recipe;
+  std::vector<synapse_helpers::device_ptr> addresses;
+  std::vector<synapse_helpers::device_ptr> input_addresses;
+  std::vector<synapse_helpers::device_ptr> output_addresses;
+  addresses.reserve(tensors.size());
+  for (std::size_t index = 0; index < tensors.size(); ++index) {
+    const auto address = reinterpret_cast<synapse_helpers::device_ptr>(
+        tensors[index].data_ptr());
+    addresses.push_back(address);
+    if (index < artifact->input_count) {
+      input_addresses.push_back(address);
+    } else {
+      output_addresses.push_back(address);
+    }
+  }
+  for (const auto position : artifact->mutable_input_positions) {
+    output_addresses.push_back(
+        addresses.at(position));
+  }
+
+  auto& device = HPUDeviceContext::get_device();
+  auto& stream = device.get_stream(hpu_stream, synapse_helpers::COMPUTE);
+  device.add_wait_events_on_stream(input_addresses, stream);
+  std::vector<synLaunchTensorInfo> launch_info;
+  launch_info.reserve(tensors.size());
+  for (std::size_t index = 0; index < tensors.size(); ++index) {
+    synLaunchTensorInfo info{};
+    info.tensorName = recipe->tensor_names[index].c_str();
+    info.pTensorAddress = addresses[index];
+    info.tensorType = DATA_TENSOR;
+    if (artifact->kernel_kind == KernelKind::SiluAndMul ||
+        artifact->kernel_kind == KernelKind::GdnDecodePacked ||
+        artifact->kernel_kind == KernelKind::GdnDecodeConvPacked ||
+        artifact->kernel_kind == KernelKind::GdnQkConvPacked ||
+        artifact->kernel_kind == KernelKind::GdnDecodeValueConvPacked) {
+      for (std::size_t dimension = 0;
+           dimension < static_cast<std::size_t>(tensors[index].dim());
+           ++dimension) {
+        info.tensorSize[dimension] = static_cast<std::uint64_t>(
+            tensors[index].size(tensors[index].dim() - dimension - 1));
+      }
+    } else {
+      info.tensorSize[0] = static_cast<std::uint64_t>(tensors[index].numel());
+    }
+    info.tensorId = recipe->tensor_ids[index];
+    launch_info.push_back(info);
+  }
+  std::vector<synapse_helpers::shared_event> external_events;
+  synapse_helpers::graph::launch(
+      device,
+      *recipe->handle,
+      recipe->workspace_size,
+      launch_info,
+      resources->address_lock,
+      external_events,
+      stream);
+
+  // Binding the completion event to outputs lets later Bridge work consume the
+  // result without a host synchronization.  The callback retains every input,
+  // the recipe and the allocator address lock until device completion.
+  device.register_producer_on_stream(
+      std::move(output_addresses),
+      stream,
+      [resources = std::move(resources)]() mutable { resources.reset(); });
+}
+
+void launch_v2(
+    std::uint64_t handle,
+    std::uint64_t hpu_stream,
+    const std::vector<at::Tensor>& tensors,
+    const std::vector<std::uint8_t>& packet) {
+  const auto artifact = lookup(handle);
+  require(
+      packet.size() >= sizeof(LaunchPacketHeaderV2),
+      "truncated launch ABI v2 packet");
+  LaunchPacketHeaderV2 header{};
+  std::memcpy(&header, packet.data(), sizeof(header));
+  require(
+      std::memcmp(header.magic, kLaunchPacketMagic, sizeof(header.magic)) == 0 &&
+          header.abi_major == kBridgeLaunchAbiMajor &&
+          header.abi_minor <= kBridgeLaunchAbiMinor,
+      "unsupported launch ABI v2 packet");
+  require(
+      header.reserved[0] == 0 && header.reserved[1] == 0,
+      "launch ABI v2 reserved bytes must be zero");
+  require(
+      header.grid_rank >= 1 && header.grid_rank <= 3 &&
+          header.tensor_count <= kMaxLaunchTensors &&
+          header.scalar_count <= kMaxScalarParams,
+      "launch ABI v2 packet exceeds the current TPC limits");
+  const std::size_t expected_size = sizeof(header) +
+      static_cast<std::size_t>(header.tensor_count) *
+          sizeof(TensorBindingV2) +
+      static_cast<std::size_t>(header.scalar_count) *
+          sizeof(ScalarBindingV2);
+  require(
+      header.struct_size == expected_size && packet.size() == expected_size,
+      "truncated or trailing data in launch ABI v2 packet");
+  for (std::size_t index = header.grid_rank;
+       index < kMaxIndexSpaceRank;
+       ++index) {
+    require(header.grid[index] == 0, "launch ABI v2 grid padding must be zero");
+  }
+  require(
+      std::string(header.artifact_hash, kArtifactHashChars) == artifact->hash,
+      "launch packet and registered artifact hashes differ");
+  require(
+      header.tensor_count == tensors.size() &&
+          header.tensor_count == artifact->tensor_argument_indices.size(),
+      "launch ABI v2 tensor binding count mismatch");
+  require(
+      header.scalar_count == artifact->scalar_argument_indices.size(),
+      "launch ABI v2 scalar binding count mismatch");
+
+  std::size_t offset = sizeof(header);
+  for (std::size_t index = 0; index < header.tensor_count; ++index) {
+    TensorBindingV2 binding{};
+    std::memcpy(&binding, packet.data() + offset, sizeof(binding));
+    require(
+        binding.argument_index == artifact->tensor_argument_indices.at(index) &&
+            binding.dtype == artifact->tensor_dtype_codes.at(index) &&
+            binding.role == artifact->tensor_roles.at(index) &&
+            binding.flags == 0,
+        "launch ABI v2 tensor binding does not match the artifact manifest");
+    offset += sizeof(binding);
+  }
+
+  std::vector<std::uint32_t> scalar_params;
+  scalar_params.reserve(header.scalar_count);
+  for (std::size_t index = 0; index < header.scalar_count; ++index) {
+    ScalarBindingV2 binding{};
+    std::memcpy(&binding, packet.data() + offset, sizeof(binding));
+    const auto& expected_dtype = artifact->scalar_dtypes.at(index);
+    require(
+        binding.argument_index == artifact->scalar_argument_indices.at(index) &&
+            binding.dtype == dtype_code(expected_dtype) &&
+            binding.reserved == 0,
+        "launch ABI v2 scalar binding does not match the artifact manifest");
+    require(
+        (expected_dtype == "i32" || expected_dtype == "u32" ||
+         expected_dtype == "f32") &&
+            binding.bits <= std::numeric_limits<std::uint32_t>::max(),
+        "the current TPC node-params ABI accepts 32-bit scalars only");
+    scalar_params.push_back(static_cast<std::uint32_t>(binding.bits));
+    offset += sizeof(binding);
+  }
+
+  std::vector<std::uint64_t> grid{
+      header.grid[0],
+      header.grid_rank >= 2 ? header.grid[1] : 1,
+      header.grid_rank >= 3 ? header.grid[2] : 1};
+  launch(handle, grid, hpu_stream, tensors, scalar_params);
+}
+
+} // namespace habana::triton_gaudi

--- a/backend/triton_gaudi_runtime.cpp
+++ b/backend/triton_gaudi_runtime.cpp
@@ -541,8 +541,9 @@ std::shared_ptr<Artifact> parse_artifact(
     const auto dtype = argument.at("dtype").get<std::string>();
     if (kind == "tensor") {
       require(
-          dtype == "f32" || dtype == "bf16" || dtype == "i32",
-          "launch ABI supports FP32, BF16, and I32 tensors only");
+          dtype == "f32" || dtype == "bf16" || dtype == "i32" ||
+              dtype == "fp8e4nv",
+          "launch ABI supports FP32, BF16, I32, and Gaudi2 E4M3 tensors only");
       tensor_order.push_back(index);
     } else {
       require(
@@ -717,6 +718,19 @@ std::shared_ptr<Artifact> parse_artifact(
             scalar_dtypes == std::vector<std::string>({"f32"}) &&
             artifact->bound_scalar_position < 0,
         "fused add+RMSNorm artifact has an incompatible tensor or scalar ABI");
+  } else if (kind == "dynamic_quant") {
+    artifact->kernel_kind = KernelKind::DynamicQuant;
+    const auto& parameters = manifest.at("parameters");
+    artifact->logical_size = parameters.at("n_cols").get<std::uint32_t>();
+    require(
+        input_args.get<std::vector<std::size_t>>() ==
+                std::vector<std::size_t>({0}) &&
+            output_args == std::vector<std::size_t>({1, 2}) &&
+            scalar_order.empty() && artifact->bound_scalar_position < 0 &&
+            parameters.at("fp8_max").get<double>() == 240.0 &&
+            std::abs(parameters.at("scale_epsilon").get<double>() - 1.0e-8) <=
+                1.0e-14,
+        "dynamic FP8 quantization artifact has an incompatible tensor or scalar ABI");
   } else if (kind == "silu_and_mul") {
     artifact->kernel_kind = KernelKind::SiluAndMul;
     const auto& parameters = manifest.at("parameters");
@@ -833,9 +847,12 @@ std::shared_ptr<Artifact> parse_artifact(
     require(kind == "elementwise", "manifest has an unsupported TPC kernel kind");
   }
   const auto tensor_dtype = manifest.value("tensor_dtype", "");
-  artifact->dtype = tensor_dtype == "bf16" ? at::kBFloat16 : at::kFloat;
+  artifact->dtype = tensor_dtype == "bf16" ? at::kBFloat16
+      : tensor_dtype == "fp8e4nv"          ? at::kFloat8_e4m3fn
+                                           : at::kFloat;
   require(
-      tensor_dtype == "f32" || tensor_dtype == "bf16",
+      tensor_dtype == "f32" || tensor_dtype == "bf16" ||
+          tensor_dtype == "fp8e4nv",
       "manifest has an unsupported tensor dtype");
   artifact->tensor_dtypes.reserve(tensor_order.size());
   artifact->tensor_dtype_codes.reserve(tensor_order.size());
@@ -844,13 +861,15 @@ std::shared_ptr<Artifact> parse_artifact(
       const auto argument_dtype = argument.at("dtype").get<std::string>();
       artifact->tensor_dtype_codes.push_back(dtype_code(argument_dtype));
       artifact->tensor_dtypes.push_back(
-          argument_dtype == "bf16"
-              ? at::kBFloat16
-              : argument_dtype == "i32" ? at::kInt : at::kFloat);
+          argument_dtype == "bf16"          ? at::kBFloat16
+              : argument_dtype == "i32"     ? at::kInt
+              : argument_dtype == "fp8e4nv" ? at::kFloat8_e4m3fn
+                                            : at::kFloat);
       if (artifact->kernel_kind != KernelKind::GdnDecodePacked &&
           artifact->kernel_kind != KernelKind::GdnDecodeConvPacked &&
           artifact->kernel_kind != KernelKind::GdnQkConvPacked &&
-          artifact->kernel_kind != KernelKind::GdnDecodeValueConvPacked) {
+          artifact->kernel_kind != KernelKind::GdnDecodeValueConvPacked &&
+          artifact->kernel_kind != KernelKind::DynamicQuant) {
         require(
             argument_dtype == tensor_dtype,
             "all generic TPC tensor arguments must use the manifest dtype");
@@ -867,6 +886,19 @@ std::shared_ptr<Artifact> parse_artifact(
             artifact->block_size <= 8192 &&
             (artifact->block_size & (artifact->block_size - 1)) == 0,
         "fused add+RMSNorm requires BF16 and a supported power-of-two block size");
+  } else if (artifact->kernel_kind == KernelKind::DynamicQuant) {
+    const std::vector<at::ScalarType> expected_dtypes{
+        at::kBFloat16, at::kFloat8_e4m3fn, at::kFloat};
+    require(
+        artifact->dtype == at::kFloat8_e4m3fn &&
+            artifact->tensor_dtypes == expected_dtypes &&
+            artifact->logical_size > 0 &&
+            artifact->logical_size <= artifact->block_size &&
+            (artifact->logical_size == 1 ||
+             artifact->logical_size > artifact->block_size / 2) &&
+            artifact->block_size <= 16384 &&
+            (artifact->block_size & (artifact->block_size - 1)) == 0,
+        "dynamic quantization requires BF16 to E4M3/f32 and a supported block size");
   } else if (artifact->kernel_kind == KernelKind::SiluAndMul) {
     require(
         artifact->dtype == at::kBFloat16 &&
@@ -924,8 +956,7 @@ std::shared_ptr<Artifact> parse_artifact(
             (artifact->block_size == 128 || artifact->block_size == 256 ||
              artifact->block_size == 512),
         "packed Q/K convolution requires canonical dtypes and channel tile");
-  } else if (
-      artifact->kernel_kind == KernelKind::GdnDecodeValueConvPacked) {
+  } else if (artifact->kernel_kind == KernelKind::GdnDecodeValueConvPacked) {
     const std::vector<at::ScalarType> expected_dtypes{
         at::kBFloat16,
         at::kFloat,
@@ -1004,6 +1035,8 @@ LaunchParamsV1 make_launch_params(
   params.logical_size = artifact.logical_size;
   params.tensor_dtype = artifact.dtype == at::kBFloat16
       ? 1U << 8 // tpc_lib_api::DATA_BF16
+      : artifact.dtype == at::kFloat8_e4m3fn
+      ? 1U << 5 // tpc_lib_api::DATA_F8_143
       : 1U << 12; // tpc_lib_api::DATA_F32
   params.kernel_kind = artifact.kernel_kind;
   std::copy_n(
@@ -1279,6 +1312,15 @@ void launch(
             static_cast<std::uint64_t>(tensors[3].numel()) == matrix_elements &&
             static_cast<std::uint64_t>(tensors[4].numel()) == matrix_elements,
         "fused add+RMSNorm tensor storage does not match grid rows and n_cols");
+  } else if (artifact->kernel_kind == KernelKind::DynamicQuant) {
+    const auto n_cols = artifact->logical_size;
+    const auto matrix_elements = grid[0] * static_cast<std::uint64_t>(n_cols);
+    require(
+        tensors.size() == 3 &&
+            static_cast<std::uint64_t>(tensors[0].numel()) == matrix_elements &&
+            static_cast<std::uint64_t>(tensors[1].numel()) == matrix_elements &&
+            static_cast<std::uint64_t>(tensors[2].numel()) == grid[0],
+        "dynamic quantization tensor storage does not match grid rows and n_cols");
   } else if (artifact->kernel_kind == KernelKind::SiluAndMul) {
     const auto n_cols = artifact->logical_size;
     const auto rows = grid[1];
@@ -1340,8 +1382,7 @@ void launch(
             tensors[3].sizes() == at::IntArrayRef({4, 10240}) &&
             tensors[4].sizes() == at::IntArrayRef({batch, 4096}),
         "packed Q/K convolution tensor storage does not match Qwen3.5");
-  } else if (
-      artifact->kernel_kind == KernelKind::GdnDecodeValueConvPacked) {
+  } else if (artifact->kernel_kind == KernelKind::GdnDecodeValueConvPacked) {
     const auto batch = static_cast<std::int64_t>(grid[2]);
     const auto conv_slots = static_cast<std::int64_t>(scalar_params.at(0));
     const auto state_slots = static_cast<std::int64_t>(scalar_params.at(1));

--- a/backend/triton_gaudi_runtime.cpp
+++ b/backend/triton_gaudi_runtime.cpp
@@ -1124,6 +1124,8 @@ std::shared_ptr<CompiledRecipe> compile_recipe(
     std::vector<std::int64_t> shape;
     std::vector<std::int64_t> stride;
     if (artifact->kernel_kind == KernelKind::SiluAndMul ||
+        artifact->kernel_kind == KernelKind::DynamicQuant ||
+        artifact->kernel_kind == KernelKind::SiluAndMulDynamicQuant ||
         artifact->kernel_kind == KernelKind::GdnDecodePacked ||
         artifact->kernel_kind == KernelKind::GdnDecodeConvPacked ||
         artifact->kernel_kind == KernelKind::GdnQkConvPacked ||
@@ -1345,9 +1347,14 @@ void launch(
   } else if (
       artifact->kernel_kind == KernelKind::SiluAndMulDynamicQuant) {
     const auto n_cols = artifact->logical_size;
+    const auto rows = static_cast<std::int64_t>(grid[0]);
     const auto matrix_elements = grid[0] * static_cast<std::uint64_t>(n_cols);
     require(
-        tensors.size() == 3 &&
+        tensors.size() == 3 && tensors[0].dim() == 2 &&
+            tensors[1].dim() == 2 && tensors[2].dim() == 2 &&
+            tensors[0].sizes() == at::IntArrayRef({rows, 2 * n_cols}) &&
+            tensors[1].sizes() == at::IntArrayRef({rows, n_cols}) &&
+            tensors[2].sizes() == at::IntArrayRef({rows, 1}) &&
             static_cast<std::uint64_t>(tensors[0].numel()) ==
                 2 * matrix_elements &&
             static_cast<std::uint64_t>(tensors[1].numel()) == matrix_elements &&
@@ -1355,9 +1362,14 @@ void launch(
         "fused SiLU-and-mul dynamic quantization tensor storage does not match grid rows and n_cols");
   } else if (artifact->kernel_kind == KernelKind::DynamicQuant) {
     const auto n_cols = artifact->logical_size;
+    const auto rows = static_cast<std::int64_t>(grid[0]);
     const auto matrix_elements = grid[0] * static_cast<std::uint64_t>(n_cols);
     require(
-        tensors.size() == 3 &&
+        tensors.size() == 3 && tensors[0].dim() == 2 &&
+            tensors[1].dim() == 2 && tensors[2].dim() == 2 &&
+            tensors[0].sizes() == at::IntArrayRef({rows, n_cols}) &&
+            tensors[1].sizes() == at::IntArrayRef({rows, n_cols}) &&
+            tensors[2].sizes() == at::IntArrayRef({rows, 1}) &&
             static_cast<std::uint64_t>(tensors[0].numel()) == matrix_elements &&
             static_cast<std::uint64_t>(tensors[1].numel()) == matrix_elements &&
             static_cast<std::uint64_t>(tensors[2].numel()) == grid[0],

--- a/backend/triton_gaudi_runtime.h
+++ b/backend/triton_gaudi_runtime.h
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+#pragma once
+
+#include <ATen/core/Tensor.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace habana::triton_gaudi {
+
+std::uint64_t register_artifact(
+    const std::string& artifact_hash,
+    const std::vector<std::uint8_t>& elf,
+    const std::string& manifest_json,
+    int device_id);
+
+std::uint64_t register_artifact_v2(
+    const std::vector<std::uint8_t>& artifact,
+    int device_id);
+
+void unregister_artifact(std::uint64_t handle);
+
+void launch(
+    std::uint64_t handle,
+    const std::vector<std::uint64_t>& grid,
+    std::uint64_t hpu_stream,
+    const std::vector<at::Tensor>& tensors,
+    const std::vector<std::uint32_t>& scalar_params);
+
+void launch_v2(
+    std::uint64_t handle,
+    std::uint64_t hpu_stream,
+    const std::vector<at::Tensor>& tensors,
+    const std::vector<std::uint8_t>& packet);
+
+} // namespace habana::triton_gaudi

--- a/include/habanalabs/triton_gaudi_launch.h
+++ b/include/habanalabs/triton_gaudi_launch.h
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+namespace habana::triton_gaudi {
+
+inline constexpr std::uint32_t kLaunchParamsMagic = 0x31475452U;
+inline constexpr std::uint16_t kLaunchAbiMajor = 1;
+inline constexpr std::uint16_t kLaunchAbiMinor = 7;
+inline constexpr std::uint16_t kBridgeLaunchAbiMajor = 2;
+inline constexpr std::uint16_t kBridgeLaunchAbiMinor = 0;
+inline constexpr std::size_t kArtifactHashChars = 64;
+inline constexpr std::size_t kMaxIndexSpaceRank = 5;
+inline constexpr std::size_t kMaxScalarParams = 32;
+inline constexpr std::size_t kMaxLaunchTensors = 64;
+inline constexpr char kKernelGuid[] = "triton_gaudi2_v1";
+inline constexpr char kBridgeKernelGuid[] = "triton_gaudi2_v2";
+inline constexpr char kLaunchPacketMagic[4] = {'G', 'A', 'L', '2'};
+inline constexpr char kArtifactManifestMagic[8] = {
+    'G', 'T', 'R', 'M', 'A', 'N', '0', '1'};
+inline constexpr std::uint16_t kArtifactManifestAbiMajor = 1;
+inline constexpr std::uint16_t kArtifactManifestAbiMinor = 0;
+
+enum class KernelKind : std::uint32_t {
+  Elementwise = 0,
+  FusedAddRmsNorm = 1,
+  SiluAndMul = 2,
+  GdnDecodePacked = 3,
+  GdnDecodeConvPacked = 4,
+  GdnQkConvPacked = 5,
+  GdnDecodeValueConvPacked = 6,
+};
+
+struct LaunchParamsV1 {
+  std::uint32_t magic{kLaunchParamsMagic};
+  std::uint16_t abi_major{kLaunchAbiMajor};
+  std::uint16_t abi_minor{kLaunchAbiMinor};
+  std::uint16_t input_count{0};
+  std::uint16_t output_count{0};
+  std::uint16_t scalar_count{0};
+  std::uint16_t index_space_rank{1};
+  std::uint32_t block_size{0};
+  std::uint32_t logical_size{0};
+  std::uint32_t tensor_dtype{0};
+  KernelKind kernel_kind{KernelKind::Elementwise};
+  std::array<std::uint64_t, kMaxIndexSpaceRank> grid{};
+  std::array<std::uint32_t, kMaxScalarParams> scalar_params{};
+  std::array<char, kArtifactHashChars + 1> artifact_hash{};
+};
+
+enum class DTypeV2 : std::uint8_t {
+  BFloat16 = 1,
+  Float16 = 2,
+  Float32 = 3,
+  Float64 = 4,
+  Int8 = 5,
+  Int16 = 6,
+  Int32 = 7,
+  Int64 = 8,
+  UInt8 = 9,
+  UInt16 = 10,
+  UInt32 = 11,
+  UInt64 = 12,
+  Float8E4NV = 13,
+  Float8E5 = 14,
+  Bool = 15,
+};
+
+enum class TensorRoleV2 : std::uint8_t {
+  Input = 1,
+  Output = 2,
+  MutableInput = 3,
+};
+
+#pragma pack(push, 1)
+
+struct ArtifactIndexMappingV1 {
+  std::uint32_t index_space_dim;
+  float a;
+  float start_b;
+  float end_b;
+  std::uint32_t all_required;
+};
+
+struct ArtifactTensorAccessV1 {
+  std::uint32_t flags;
+  ArtifactIndexMappingV1 mappings[kMaxIndexSpaceRank];
+};
+
+struct ArtifactManifestV1 {
+  char magic[8];
+  std::uint16_t abi_major;
+  std::uint16_t abi_minor;
+  std::uint32_t struct_size;
+  std::uint16_t index_space_rank;
+  std::uint16_t input_count;
+  std::uint16_t output_count;
+  std::uint16_t reserved;
+  ArtifactTensorAccessV1 tensor_access[kMaxLaunchTensors];
+};
+
+struct LaunchPacketHeaderV2 {
+  char magic[4];
+  std::uint16_t abi_major;
+  std::uint16_t abi_minor;
+  std::uint32_t struct_size;
+  char artifact_hash[kArtifactHashChars];
+  std::uint16_t grid_rank;
+  std::uint16_t tensor_count;
+  std::uint16_t scalar_count;
+  std::uint8_t reserved[2];
+  std::uint64_t grid[kMaxIndexSpaceRank];
+};
+
+struct TensorBindingV2 {
+  std::uint16_t argument_index;
+  DTypeV2 dtype;
+  TensorRoleV2 role;
+  std::uint32_t flags;
+};
+
+struct ScalarBindingV2 {
+  std::uint16_t argument_index;
+  DTypeV2 dtype;
+  std::uint8_t reserved;
+  std::uint64_t bits;
+};
+
+#pragma pack(pop)
+
+static_assert(std::is_standard_layout_v<LaunchParamsV1>);
+static_assert(std::is_trivially_copyable_v<LaunchParamsV1>);
+static_assert(sizeof(LaunchParamsV1) == 272);
+static_assert(sizeof(ArtifactIndexMappingV1) == 20);
+static_assert(sizeof(ArtifactTensorAccessV1) == 104);
+static_assert(sizeof(ArtifactManifestV1) == 6680);
+static_assert(sizeof(LaunchPacketHeaderV2) == 124);
+static_assert(sizeof(TensorBindingV2) == 8);
+static_assert(sizeof(ScalarBindingV2) == 12);
+
+} // namespace habana::triton_gaudi

--- a/include/habanalabs/triton_gaudi_launch.h
+++ b/include/habanalabs/triton_gaudi_launch.h
@@ -15,7 +15,7 @@ namespace habana::triton_gaudi {
 
 inline constexpr std::uint32_t kLaunchParamsMagic = 0x31475452U;
 inline constexpr std::uint16_t kLaunchAbiMajor = 1;
-inline constexpr std::uint16_t kLaunchAbiMinor = 8;
+inline constexpr std::uint16_t kLaunchAbiMinor = 9;
 inline constexpr std::uint16_t kBridgeLaunchAbiMajor = 2;
 inline constexpr std::uint16_t kBridgeLaunchAbiMinor = 0;
 inline constexpr std::size_t kArtifactHashChars = 64;
@@ -39,6 +39,7 @@ enum class KernelKind : std::uint32_t {
   GdnQkConvPacked = 5,
   GdnDecodeValueConvPacked = 6,
   DynamicQuant = 7,
+  SiluAndMulDynamicQuant = 8,
 };
 
 struct LaunchParamsV1 {

--- a/include/habanalabs/triton_gaudi_launch.h
+++ b/include/habanalabs/triton_gaudi_launch.h
@@ -15,7 +15,7 @@ namespace habana::triton_gaudi {
 
 inline constexpr std::uint32_t kLaunchParamsMagic = 0x31475452U;
 inline constexpr std::uint16_t kLaunchAbiMajor = 1;
-inline constexpr std::uint16_t kLaunchAbiMinor = 7;
+inline constexpr std::uint16_t kLaunchAbiMinor = 8;
 inline constexpr std::uint16_t kBridgeLaunchAbiMajor = 2;
 inline constexpr std::uint16_t kBridgeLaunchAbiMinor = 0;
 inline constexpr std::size_t kArtifactHashChars = 64;
@@ -38,6 +38,7 @@ enum class KernelKind : std::uint32_t {
   GdnDecodeConvPacked = 4,
   GdnQkConvPacked = 5,
   GdnDecodeValueConvPacked = 6,
+  DynamicQuant = 7,
 };
 
 struct LaunchParamsV1 {

--- a/include/habanalabs/triton_gaudi_launch.h
+++ b/include/habanalabs/triton_gaudi_launch.h
@@ -15,9 +15,9 @@ namespace habana::triton_gaudi {
 
 inline constexpr std::uint32_t kLaunchParamsMagic = 0x31475452U;
 inline constexpr std::uint16_t kLaunchAbiMajor = 1;
-inline constexpr std::uint16_t kLaunchAbiMinor = 9;
+inline constexpr std::uint16_t kLaunchAbiMinor = 10;
 inline constexpr std::uint16_t kBridgeLaunchAbiMajor = 2;
-inline constexpr std::uint16_t kBridgeLaunchAbiMinor = 0;
+inline constexpr std::uint16_t kBridgeLaunchAbiMinor = 1;
 inline constexpr std::size_t kArtifactHashChars = 64;
 inline constexpr std::size_t kMaxIndexSpaceRank = 5;
 inline constexpr std::size_t kMaxScalarParams = 32;

--- a/python_packages/habana_frameworks/torch/_hpu_C.py
+++ b/python_packages/habana_frameworks/torch/_hpu_C.py
@@ -25,6 +25,13 @@ if _is_torch_fork:
         _hpu_setStream,
         _HpuEventBase,
         _HpuStreamBase,
+        _triton_gaudi_device_properties,
+        _triton_gaudi_launch,
+        _triton_gaudi_launch_v2,
+        _triton_gaudi_launch_abi,
+        _triton_gaudi_register_artifact,
+        _triton_gaudi_register_artifact_v2,
+        _triton_gaudi_unregister_artifact,
     )
 else:
     from habana_frameworks.torch.lib.upstream_pybind._hpu_C import *
@@ -36,4 +43,11 @@ else:
         _hpu_setStream,
         _HpuEventBase,
         _HpuStreamBase,
+        _triton_gaudi_device_properties,
+        _triton_gaudi_launch,
+        _triton_gaudi_launch_v2,
+        _triton_gaudi_launch_abi,
+        _triton_gaudi_register_artifact,
+        _triton_gaudi_register_artifact_v2,
+        _triton_gaudi_unregister_artifact,
     )

--- a/python_packages/habana_frameworks/torch/dynamo/compile_backend/passes.py
+++ b/python_packages/habana_frameworks/torch/dynamo/compile_backend/passes.py
@@ -135,6 +135,7 @@ def get_passes(stage: OptimizationPassPlacement):
             pass_allreduce_parents,
             pass_pattern_rewriter,
             pass_scalar_reorder_jitfork,
+            pass_reinplace_triton_gaudi_gdn_decode,
             pass_fake_propagation,
             pass_reinplace_inplaceable_ops_v2,
             pass_weight_permutation,
@@ -2318,6 +2319,318 @@ def pass_reinplace_inplaceable_ops(ctx: OptimizerContext) -> bool:
         return graph_changed
 
     return reinplace_collective_ops(ctx.graph_module)
+
+
+def pass_reinplace_triton_gaudi_gdn_decode(ctx: OptimizerContext) -> bool:
+    """Remove AOTAutograd's full-cache copies around packed GDN decode.
+
+    This handles both the recurrent-only one-cache candidate and the fused
+    causal-conv + GDN two-cache kernel. Reinsert a mutating operator only when
+    every functionalized base has exactly one matching copy-back and no other
+    consumer. Any alias, extra state consumer, unexpected output ordering, or
+    malformed kwargs leaves the generic functionalization intact.
+    """
+    try:
+        auto_functionalized = torch.ops.higher_order.auto_functionalized_v2
+    except AttributeError:
+        return False
+
+    candidates = []
+    try:
+        candidates.append((
+            torch.ops.triton_gaudi.gdn_decode_packed.default,
+            ("state_cache",),
+            {
+                "packed_qkv",
+                "gate_a",
+                "gate_b",
+                "a_log",
+                "dt_bias",
+                "state_indices",
+                "artifact_hash",
+                "value_tile",
+            },
+        ))
+    except AttributeError:
+        pass
+    try:
+        candidates.append((
+            torch.ops.triton_gaudi.gdn_decode_conv_packed.default,
+            ("conv_state", "state_cache"),
+            {
+                "packed_qkv",
+                "gate_a",
+                "gate_b",
+                "a_log",
+                "dt_bias",
+                "state_indices",
+                "conv_weight_t",
+                "artifact_hash",
+            },
+        ))
+    except AttributeError:
+        pass
+    try:
+        candidates.append((
+            torch.ops.triton_gaudi.gdn_qk_conv_packed.default,
+            ("conv_state",),
+            {
+                "packed_qkv",
+                "state_indices",
+                "conv_weight_t",
+                "artifact_hash",
+            },
+        ))
+    except AttributeError:
+        pass
+    try:
+        candidates.append((
+            torch.ops.triton_gaudi.gdn_decode_value_conv_packed.default,
+            ("conv_state", "state_cache"),
+            {
+                "qk_conv",
+                "packed_qkv",
+                "gate_a",
+                "gate_b",
+                "a_log",
+                "dt_bias",
+                "state_indices",
+                "conv_weight_t",
+                "artifact_hash",
+                "value_tile",
+            },
+        ))
+    except AttributeError:
+        pass
+    if not candidates:
+        return False
+
+    graph = ctx.graph_module.graph
+    changed = False
+
+    # The split kernel forms a two-op mutation chain. Functionalization feeds
+    # the cloned conv cache returned by Q/K conv into value-conv + GDN, then
+    # copies only the final cache back to the original base. Rewrite the pair
+    # atomically; neither node is independently safe to reinplace first.
+    try:
+        qk_op = torch.ops.triton_gaudi.gdn_qk_conv_packed.default
+        value_op = torch.ops.triton_gaudi.gdn_decode_value_conv_packed.default
+    except AttributeError:
+        qk_op = None
+        value_op = None
+    if qk_op is not None and value_op is not None:
+        qk_public = {
+            "packed_qkv",
+            "state_indices",
+            "conv_weight_t",
+            "artifact_hash",
+        }
+        value_public = {
+            "qk_conv",
+            "packed_qkv",
+            "gate_a",
+            "gate_b",
+            "a_log",
+            "dt_bias",
+            "state_indices",
+            "conv_weight_t",
+            "artifact_hash",
+            "value_tile",
+        }
+        for value_node in list(graph.nodes):
+            if (value_node.op != "call_function" or
+                    value_node.target != auto_functionalized or
+                    len(value_node.args) != 1 or value_node.args[0] != value_op or
+                    set(value_node.kwargs) != value_public | {
+                        "_conv_state_base_index",
+                        "_state_cache_base_index",
+                        "_all_bases",
+                    } or value_node.kwargs["_conv_state_base_index"] != 0 or
+                    value_node.kwargs["_state_cache_base_index"] != 1):
+                continue
+            value_bases = value_node.kwargs["_all_bases"]
+            if (not isinstance(value_bases, (list, tuple)) or
+                    len(value_bases) != 2):
+                continue
+            intermediate_conv, state_base = value_bases
+            if (not isinstance(intermediate_conv, torch.fx.Node) or
+                    not isinstance(state_base, torch.fx.Node) or
+                    intermediate_conv.op != "call_function" or
+                    intermediate_conv.target != operator.getitem or
+                    len(intermediate_conv.args) != 2 or
+                    intermediate_conv.args[1] != 1):
+                continue
+            qk_node = intermediate_conv.args[0]
+            if (not isinstance(qk_node, torch.fx.Node) or
+                    qk_node.op != "call_function" or
+                    qk_node.target != auto_functionalized or
+                    len(qk_node.args) != 1 or qk_node.args[0] != qk_op or
+                    set(qk_node.kwargs) != qk_public | {
+                        "_conv_state_base_index",
+                        "_all_bases",
+                    } or qk_node.kwargs["_conv_state_base_index"] != 0):
+                continue
+            qk_bases = qk_node.kwargs["_all_bases"]
+            if (not isinstance(qk_bases, (list, tuple)) or len(qk_bases) != 1 or
+                    not isinstance(qk_bases[0], torch.fx.Node)):
+                continue
+            conv_base = qk_bases[0]
+            qk_getitems = {
+                user.args[1]: user
+                for user in qk_node.users
+                if user.op == "call_function" and
+                user.target == operator.getitem and len(user.args) == 2 and
+                user.args[0] is qk_node and isinstance(user.args[1], int)
+            }
+            value_getitems = {
+                user.args[1]: user
+                for user in value_node.users
+                if user.op == "call_function" and
+                user.target == operator.getitem and len(user.args) == 2 and
+                user.args[0] is value_node and isinstance(user.args[1], int)
+            }
+            if (set(qk_getitems) != {0, 1} or len(qk_node.users) != 2 or
+                    set(value_getitems) != {0, 1, 2} or
+                    len(value_node.users) != 3 or
+                    qk_getitems[1] is not intermediate_conv or
+                    value_node.kwargs["qk_conv"] is not qk_getitems[0] or
+                    set(intermediate_conv.users) != {value_node} or
+                    set(qk_getitems[0].users) != {value_node}):
+                continue
+            copies = []
+            valid = True
+            for base, getitem in (
+                    (conv_base, value_getitems[1]),
+                    (state_base, value_getitems[2]),
+            ):
+                users = list(getitem.users)
+                if len(users) != 1:
+                    valid = False
+                    break
+                copy_node = users[0]
+                if (copy_node.op != "call_function" or
+                        copy_node.target != torch.ops.aten.copy_.default or
+                        len(copy_node.args) < 2 or copy_node.args[0] is not base or
+                        copy_node.args[1] is not getitem):
+                    valid = False
+                    break
+                copies.append((base, getitem, copy_node))
+            if (not valid or set(conv_base.users) != {qk_node, copies[0][2]} or
+                    set(state_base.users) != {value_node, copies[1][2]}):
+                continue
+
+            with graph.inserting_before(qk_node):
+                direct_qk = graph.call_function(
+                    qk_op,
+                    kwargs={
+                        "conv_state": conv_base,
+                        **{name: qk_node.kwargs[name] for name in qk_public},
+                    },
+                )
+            direct_qk.meta = qk_getitems[0].meta.copy()
+            with graph.inserting_before(value_node):
+                direct_value = graph.call_function(
+                    value_op,
+                    kwargs={
+                        "conv_state": conv_base,
+                        "state_cache": state_base,
+                        "qk_conv": direct_qk,
+                        **{
+                            name: value_node.kwargs[name]
+                            for name in value_public if name != "qk_conv"
+                        },
+                    },
+                )
+            direct_value.meta = value_getitems[0].meta.copy()
+            value_getitems[0].replace_all_uses_with(direct_value)
+            for base, getitem, copy_node in copies:
+                copy_node.replace_all_uses_with(base)
+                graph.erase_node(copy_node)
+                graph.erase_node(getitem)
+            graph.erase_node(value_getitems[0])
+            graph.erase_node(value_node)
+            graph.erase_node(intermediate_conv)
+            graph.erase_node(qk_getitems[0])
+            graph.erase_node(qk_node)
+            changed = True
+
+    for node in list(graph.nodes):
+        if (node.op != "call_function" or
+                node.target != auto_functionalized or len(node.args) != 1):
+            continue
+        candidate = next((item for item in candidates
+                          if node.args[0] == item[0]), None)
+        if candidate is None:
+            continue
+        gdn_op, mutable_names, public_kwargs = candidate
+        internal_kwargs = {
+            *(f"_{name}_base_index" for name in mutable_names),
+            "_all_bases",
+        }
+        if (set(node.kwargs) != public_kwargs | internal_kwargs or any(
+                node.kwargs[f"_{name}_base_index"] != index
+                for index, name in enumerate(mutable_names))):
+            continue
+        bases = node.kwargs["_all_bases"]
+        if (not isinstance(bases, (list, tuple)) or
+                len(bases) != len(mutable_names) or
+                len(set(bases)) != len(bases) or
+                any(not isinstance(base, torch.fx.Node) for base in bases)):
+            continue
+
+        getitems = {
+            user.args[1]: user
+            for user in node.users
+            if user.op == "call_function"
+            and user.target == operator.getitem
+            and len(user.args) == 2
+            and user.args[0] is node
+            and isinstance(user.args[1], int)
+        }
+        expected_outputs = set(range(len(mutable_names) + 1))
+        if set(getitems) != expected_outputs or len(node.users) != len(expected_outputs):
+            continue
+        output_getitem = getitems[0]
+        copies = []
+        valid = True
+        for index, base in enumerate(bases, start=1):
+            mutated_getitem = getitems[index]
+            users = list(mutated_getitem.users)
+            if len(users) != 1:
+                valid = False
+                break
+            copy_node = users[0]
+            if (copy_node.op != "call_function" or
+                    copy_node.target != torch.ops.aten.copy_.default or
+                    len(copy_node.args) < 2 or copy_node.args[0] is not base or
+                    copy_node.args[1] is not mutated_getitem or
+                    set(base.users) != {node, copy_node}):
+                valid = False
+                break
+            copies.append((base, mutated_getitem, copy_node))
+        if not valid:
+            continue
+
+        direct_kwargs = {
+            **dict(zip(mutable_names, bases)),
+            **{name: node.kwargs[name] for name in public_kwargs},
+        }
+        with graph.inserting_before(node):
+            direct = graph.call_function(gdn_op, kwargs=direct_kwargs)
+        direct.meta = output_getitem.meta.copy()
+        output_getitem.replace_all_uses_with(direct)
+        for base, mutated_getitem, copy_node in copies:
+            copy_node.replace_all_uses_with(base)
+            graph.erase_node(copy_node)
+            graph.erase_node(mutated_getitem)
+        graph.erase_node(output_getitem)
+        graph.erase_node(node)
+        changed = True
+
+    if changed:
+        graph.lint()
+        ctx.graph_module.recompile()
+    return changed
 
 
 def pass_reinplace_inplaceable_ops_v2(ctx: OptimizerContext) -> bool:

--- a/python_packages/habana_frameworks/torch/dynamo/compile_backend/shared_layer.py
+++ b/python_packages/habana_frameworks/torch/dynamo/compile_backend/shared_layer.py
@@ -122,6 +122,17 @@ if bc.get_pt_hpu_override_linear_matmul_eager():
 
 hpu_supported_ops_restricted = {}
 
+TRITON_GAUDI_GRAPH_OPS = {
+    "dynamic_quant",
+    "fused_add_rms_norm",
+    "gdn_decode_conv_packed",
+    "gdn_decode_packed",
+    "gdn_decode_value_conv_packed",
+    "gdn_qk_conv_packed",
+    "silu_and_mul",
+    "silu_and_mul_dynamic_quant",
+}
+
 if bc.get_pt_hpu_wrap_random_ops_compile():
     hpu_supported_op_list.update(["rand", "randint", "randn", "uniform", "habana_random_wrapper"])
     hpu_supported_ops_restricted.update(
@@ -273,6 +284,12 @@ def check_for_default_op_support(op_name, node, is_dynamic):
     # Enable torch.compile for user's CustomOp API
     if hasattr(node.target, "namespace") and node.target.namespace == "custom_op":
         return True, "Graph support for user's CustomOp"
+    if (
+        hasattr(node.target, "namespace")
+        and node.target.namespace == "triton_gaudi"
+        and op_name in TRITON_GAUDI_GRAPH_OPS
+    ):
+        return True, "Graph support for the Triton Gaudi launch ABI"
     return False, ""
 
 

--- a/python_packages/habana_frameworks/torch/hpu/csrc/CMakeLists.txt
+++ b/python_packages/habana_frameworks/torch/hpu/csrc/CMakeLists.txt
@@ -32,5 +32,6 @@ target_link_libraries(
          absl::variant
          absl::flat_hash_map
          absl::strings
+         npu::habana_pytorch_backend
          ${TORCH_PYTHON_LIBRARY})
 install(TARGETS _hpu_C LIBRARY DESTINATION habana_torch_plugin/${PYBIND_INSTALL_DIRNAME})

--- a/python_packages/habana_frameworks/torch/hpu/csrc/bindings.cpp
+++ b/python_packages/habana_frameworks/torch/hpu/csrc/bindings.cpp
@@ -28,9 +28,11 @@
 #include "backend/habana_device/HPUGraph.h"
 #include "backend/habana_device/HPUGuardImpl.h"
 #include "backend/habana_device/hpu_cached_devices.h"
+#include "backend/triton_gaudi_runtime.h"
 #include "backend/helpers/dynamic_shape_info.h"
 #include "backend/helpers/runtime_config.h"
 #include "backend/synapse_helpers/stream.h"
+#include "include/habanalabs/triton_gaudi_launch.h"
 #include "habana_lazy/view_utils.h"
 #include "hpu_ops/custom_op_outshape.h"
 #include "pytorch_helpers/habana_helpers/kernels_accumulation.h"
@@ -245,6 +247,79 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     return habana::HPUGlobalConfig::get().getDeterministic();
   });
   m.def("get_device_name", [](int id) { return get_device_name(id); });
+  m.def(
+      "_triton_gaudi_register_artifact",
+      [](const std::string& artifact_hash,
+         py::bytes elf_bytes,
+         const std::string& manifest_json,
+         int device_id) {
+        const std::string elf = elf_bytes;
+        return habana::triton_gaudi::register_artifact(
+            artifact_hash,
+            std::vector<std::uint8_t>(elf.begin(), elf.end()),
+            manifest_json,
+            device_id);
+      });
+  m.def(
+      "_triton_gaudi_register_artifact_v2",
+      [](py::bytes artifact_bytes, int device_id) {
+        const std::string artifact = artifact_bytes;
+        return habana::triton_gaudi::register_artifact_v2(
+            std::vector<std::uint8_t>(artifact.begin(), artifact.end()),
+            device_id);
+      });
+  m.def(
+      "_triton_gaudi_unregister_artifact",
+      [](std::uint64_t handle) {
+        habana::triton_gaudi::unregister_artifact(handle);
+      });
+  m.def("_triton_gaudi_launch_abi", []() {
+    using namespace pybind11::literals;
+    return py::dict(
+        "major"_a = habana::triton_gaudi::kBridgeLaunchAbiMajor,
+        "minor"_a = habana::triton_gaudi::kBridgeLaunchAbiMinor,
+        "target"_a = "gaudi2",
+        "kernel_guid"_a = habana::triton_gaudi::kBridgeKernelGuid,
+        "graph_op"_a = true,
+        "artifact_abi"_a = 2,
+        "typed_scalars"_a = true);
+  });
+  m.def(
+      "_triton_gaudi_launch",
+      [](std::uint64_t handle,
+         const std::vector<std::uint64_t>& grid,
+         std::uint64_t stream,
+         const std::vector<at::Tensor>& tensors,
+         const std::vector<std::uint32_t>& scalar_params) {
+        py::gil_scoped_release release;
+        habana::triton_gaudi::launch(
+            handle, grid, stream, tensors, scalar_params);
+      });
+  m.def(
+      "_triton_gaudi_launch_v2",
+      [](std::uint64_t handle,
+         std::uint64_t stream,
+         const std::vector<at::Tensor>& tensors,
+         py::bytes packet_bytes) {
+        const std::string packet = packet_bytes;
+        py::gil_scoped_release release;
+        habana::triton_gaudi::launch_v2(
+            handle,
+            stream,
+            tensors,
+            std::vector<std::uint8_t>(packet.begin(), packet.end()));
+      });
+  m.def("_triton_gaudi_device_properties", [](int device_id) {
+    HABANA_ASSERT(
+        device_id ==
+            static_cast<int>(habana::HPUDeviceContext::get_device().id()),
+        "Triton Gaudi device does not match the active HPU");
+    using namespace pybind11::literals;
+    return py::dict(
+        "max_shared_mem"_a = 0,
+        "max_index_space_rank"_a = 5,
+        "vector_width_bits"_a = 2048);
+  });
   m.def("set_autocast_hpu_enabled", [](py::object enabled) {
     at::autocast::set_autocast_enabled(at::kHPU, enabled.ptr() == Py_True);
   });

--- a/python_packages/habana_frameworks/torch/jit/csrc/jit_fork/CMakeLists.txt
+++ b/python_packages/habana_frameworks/torch/jit/csrc/jit_fork/CMakeLists.txt
@@ -45,6 +45,16 @@ add_habana_library(
   passes/utils/subgraph_utils.cpp
   python/forked_pybind_utils.cpp)
 
+# SynapseAI 1.24.1's installed hl_logger headers define FMT_HEADER_ONLY even
+# when fmt::fmt-header-only has already supplied the same command-line define.
+# GCC does not attach a suppressible warning category to this diagnostic. The
+# JIT fork reaches fmt before and through hl_logger. Normalize the transitive
+# value to the empty definition used by that public header so fmt remains
+# header-only from the first include and the identical redefinition is quiet.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  target_compile_options(jit_fork PRIVATE -UFMT_HEADER_ONLY -DFMT_HEADER_ONLY)
+endif()
+
 target_link_libraries(jit_fork PUBLIC bindings torch ${TORCH_PYTHON_LIBRARY})
 
 target_include_directories(jit_fork PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/tests/pytest_working/compile/test_eager_fallback.py
+++ b/tests/pytest_working/compile/test_eager_fallback.py
@@ -13,10 +13,16 @@
 # limitations under the License.
 ###############################################################################
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 from habana_frameworks.torch.dynamo.compile_backend.random_utils import (
     HABANA_RANDOM_OPS,
+)
+from habana_frameworks.torch.dynamo.compile_backend.shared_layer import (
+    TRITON_GAUDI_GRAPH_OPS,
+    check_for_default_op_support,
 )
 from test_utils import (
     check_eager_fallback_reason,
@@ -101,6 +107,39 @@ def test_conditional_support():
     check_eager_fallback_reason(
         "sdpa_recomp_fwd_dropout", "Graph support based on hpu_supported_op_list", is_fallback=False
     )
+
+
+@pytest.mark.parametrize("op_name", sorted(TRITON_GAUDI_GRAPH_OPS))
+def test_triton_gaudi_ops_have_graph_support(op_name):
+    target = SimpleNamespace(
+        __name__=f"{op_name}.default",
+        namespace="triton_gaudi",
+    )
+
+    supported, reason = check_for_default_op_support(
+        op_name,
+        SimpleNamespace(target=target),
+        is_dynamic=False,
+    )
+
+    assert supported
+    assert reason == "Graph support for the Triton Gaudi launch ABI"
+
+
+def test_unknown_triton_gaudi_op_fails_closed():
+    target = SimpleNamespace(
+        __name__="unknown.default",
+        namespace="triton_gaudi",
+    )
+
+    supported, reason = check_for_default_op_support(
+        "unknown",
+        SimpleNamespace(target=target),
+        is_dynamic=False,
+    )
+
+    assert not supported
+    assert reason == ""
 
 
 def test_shared_layer_failed():

--- a/tests/pytest_working/compile/test_triton_gaudi_reinplace.py
+++ b/tests/pytest_working/compile/test_triton_gaudi_reinplace.py
@@ -1,0 +1,158 @@
+###############################################################################
+# Copyright (c) 2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+###############################################################################
+
+import operator
+
+import torch
+
+from habana_frameworks.torch.dynamo.compile_backend._passes.utils import (
+    OptimizationPassPlacement,
+    OptimizerContext,
+)
+from habana_frameworks.torch.dynamo.compile_backend.passes import (
+    pass_reinplace_triton_gaudi_gdn_decode,
+)
+
+
+def _make_functionalized_gdn_graph(*, extra_state_user: bool):
+    graph = torch.fx.Graph()
+    state = graph.placeholder("state")
+    packed = graph.placeholder("packed")
+    gate_a = graph.placeholder("gate_a")
+    gate_b = graph.placeholder("gate_b")
+    a_log = graph.placeholder("a_log")
+    dt_bias = graph.placeholder("dt_bias")
+    indices = graph.placeholder("indices")
+    gdn_op = torch.ops.triton_gaudi.gdn_decode_packed.default
+    functionalized = graph.call_function(
+        torch.ops.higher_order.auto_functionalized_v2,
+        args=(gdn_op,),
+        kwargs={
+            "packed_qkv": packed,
+            "gate_a": gate_a,
+            "gate_b": gate_b,
+            "a_log": a_log,
+            "dt_bias": dt_bias,
+            "state_indices": indices,
+            "artifact_hash": "0" * 64,
+            "value_tile": 16,
+            "_state_cache_base_index": 0,
+            "_all_bases": [state],
+        },
+    )
+    output = graph.call_function(operator.getitem, args=(functionalized, 0))
+    updated_state = graph.call_function(operator.getitem, args=(functionalized, 1))
+    graph.call_function(torch.ops.aten.copy_.default, args=(state, updated_state))
+    if extra_state_user:
+        alias = graph.call_function(torch.ops.aten.alias.default, args=(state,))
+        graph.output((output, alias))
+    else:
+        graph.output(output)
+    return torch.fx.GraphModule({}, graph)
+
+
+def _make_functionalized_fused_gdn_graph(*, extra_conv_user: bool):
+    graph = torch.fx.Graph()
+    conv_state = graph.placeholder("conv_state")
+    state = graph.placeholder("state")
+    packed = graph.placeholder("packed")
+    gate_a = graph.placeholder("gate_a")
+    gate_b = graph.placeholder("gate_b")
+    a_log = graph.placeholder("a_log")
+    dt_bias = graph.placeholder("dt_bias")
+    indices = graph.placeholder("indices")
+    conv_weight_t = graph.placeholder("conv_weight_t")
+    gdn_op = torch.ops.triton_gaudi.gdn_decode_conv_packed.default
+    functionalized = graph.call_function(
+        torch.ops.higher_order.auto_functionalized_v2,
+        args=(gdn_op,),
+        kwargs={
+            "packed_qkv": packed,
+            "gate_a": gate_a,
+            "gate_b": gate_b,
+            "a_log": a_log,
+            "dt_bias": dt_bias,
+            "state_indices": indices,
+            "conv_weight_t": conv_weight_t,
+            "artifact_hash": "0" * 64,
+            "_conv_state_base_index": 0,
+            "_state_cache_base_index": 1,
+            "_all_bases": [conv_state, state],
+        },
+    )
+    output = graph.call_function(operator.getitem, args=(functionalized, 0))
+    updated_conv = graph.call_function(operator.getitem, args=(functionalized, 1))
+    updated_state = graph.call_function(operator.getitem, args=(functionalized, 2))
+    graph.call_function(
+        torch.ops.aten.copy_.default,
+        args=(conv_state, updated_conv),
+    )
+    graph.call_function(torch.ops.aten.copy_.default, args=(state, updated_state))
+    if extra_conv_user:
+        alias = graph.call_function(torch.ops.aten.alias.default, args=(conv_state,))
+        graph.output((output, alias))
+    else:
+        graph.output(output)
+    return torch.fx.GraphModule({}, graph)
+
+
+def _context(graph_module):
+    return OptimizerContext(
+        graph_module,
+        "test_triton_gaudi_gdn",
+        [],
+        False,
+        False,
+        False,
+        OptimizationPassPlacement.PRE_PLACEMENT,
+        [],
+        [],
+    )
+
+
+def test_reinplace_triton_gaudi_gdn_removes_full_state_copy():
+    graph_module = _make_functionalized_gdn_graph(extra_state_user=False)
+
+    assert pass_reinplace_triton_gaudi_gdn_decode(_context(graph_module))
+
+    targets = [node.target for node in graph_module.graph.nodes]
+    assert torch.ops.higher_order.auto_functionalized_v2 not in targets
+    assert torch.ops.aten.copy_.default not in targets
+    assert targets.count(torch.ops.triton_gaudi.gdn_decode_packed.default) == 1
+
+
+def test_reinplace_triton_gaudi_gdn_fails_closed_with_extra_state_user():
+    graph_module = _make_functionalized_gdn_graph(extra_state_user=True)
+
+    assert not pass_reinplace_triton_gaudi_gdn_decode(_context(graph_module))
+
+    targets = [node.target for node in graph_module.graph.nodes]
+    assert torch.ops.higher_order.auto_functionalized_v2 in targets
+    assert torch.ops.aten.copy_.default in targets
+
+
+def test_reinplace_fused_triton_gaudi_gdn_removes_both_cache_copies():
+    graph_module = _make_functionalized_fused_gdn_graph(
+        extra_conv_user=False)
+
+    assert pass_reinplace_triton_gaudi_gdn_decode(_context(graph_module))
+
+    targets = [node.target for node in graph_module.graph.nodes]
+    assert torch.ops.higher_order.auto_functionalized_v2 not in targets
+    assert torch.ops.aten.copy_.default not in targets
+    assert targets.count(
+        torch.ops.triton_gaudi.gdn_decode_conv_packed.default) == 1
+
+
+def test_reinplace_fused_triton_gaudi_gdn_fails_closed_with_extra_cache_user():
+    graph_module = _make_functionalized_fused_gdn_graph(extra_conv_user=True)
+
+    assert not pass_reinplace_triton_gaudi_gdn_decode(_context(graph_module))
+
+    targets = [node.target for node in graph_module.graph.nodes]
+    assert torch.ops.higher_order.auto_functionalized_v2 in targets
+    assert targets.count(torch.ops.aten.copy_.default) == 2


### PR DESCRIPTION
## Summary

Add the SynapseAI 1.24.1 Bridge side of the experimental Gaudi2 Triton backend.

- define a versioned, fixed-size launch ABI for content-addressed TPC artifacts
- register the fixed `triton_gaudi2_v1` GUID and validate artifact metadata before graph compilation
- expose graph-native custom ops for elementwise, fused RMSNorm, SiLU-and-mul, and packed Qwen3.5 GDN kernels
- preserve the current HPU graph and stream instead of issuing nested `synLaunch` calls
- add strict dtype, shape, layout, hash, and index-space checks
- reinplace state-mutating GDN ops only when AOTAutograd's alias/copy-back graph is provably safe
- rewrite the two-op Q/K-conv → value-conv/GDN mutation chain atomically to avoid full-cache copies

## Dependencies

- Compiler/backend: triton-lang/triton#11545
- Bridge launch ABI: this PR
- vLLM integration: 1CatAI/1cat-vllm-gaudi#3

## Validation

- `ninja -C build/triton-gaudi`
- `python -m pytest -s --tb=short tests/pytest_working/compile/test_triton_gaudi_reinplace.py` — 4 passed
- `git diff --check origin/v1.24.1..HEAD`
- Gaudi2 eager, fullgraph, mutation, alias, and hardware graph-execution validation

## Rollout

The ABI is fail-closed. Unsupported artifacts do not silently reinterpret CUDA semantics, and the vLLM layer keeps the feature disabled unless an explicit rollout mode is selected.
